### PR TITLE
Add android:forceDarkAllowed attribute

### DIFF
--- a/app/src/main/res/values-v29/styles.xml
+++ b/app/src/main/res/values-v29/styles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="android:colorPrimaryDark">@color/status_bar</item> <!-- status bar color -->
+        <item name="android:colorPrimary">@color/apps_list</item> <!-- launched apps list -->
+        <item name="android:colorControlActivated">#ff5b95c2</item>
+        <item name="android:datePickerStyle">@style/DatePickerTheme</item>
+        <item name="android:datePickerDialogTheme">@style/DialogTheme</item>
+        <item name="android:timePickerStyle">@style/TimePickerTheme</item>
+        <item name="android:timePickerDialogTheme">@style/DialogTheme</item>
+        <item name="android:navigationBarColor">@color/navigation_bar</item>
+        <item name="android:windowBackground">@color/splash</item>
+        <item name="android:forceDarkAllowed">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
Fixes MIUI/Flyme theming (enabled by default but can be disabled by user)