### PR TITLE
Fix not working startParameter in inline keyboard

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/component/chat/InlineResultsWrap.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/chat/InlineResultsWrap.java
@@ -860,7 +860,7 @@ public class InlineResultsWrap extends FrameLayoutFix implements View.OnClickLis
           UI.post(() -> {
             if (!isCancelled()) {
               setItems(null);
-              delegate.tdlib().ui().openChat(c, chatId, new TdlibUi.ChatOpenParameters().shareItem(new TGBotStart(delegate.tdlib().chatUserId(chatId), button.data(), false)));
+              delegate.tdlib().ui().openChat(c, chatId, new TdlibUi.ChatOpenParameters().keepStack().shareItem(new TGBotStart(delegate.tdlib().chatUserId(chatId), button.data(), false)));
             }
           });
         } else {


### PR DESCRIPTION
Previously, startPm button only takes to the bot itself and the «Start» button doesn’t send any data to the bot.