### PR TITLE
Fix OutOfBounds exception when loading poll voters

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/telegram/ListManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/telegram/ListManager.java
@@ -310,7 +310,6 @@ public abstract class ListManager<T> implements Destroyable, Iterable<T> {
   }
 
   protected final void notifyItemChanged (int index, int cause) {
-    if (index == -1) return;
     T item = items.get(index);
     for (int i = changeListeners.size() - 1; i >= 0; i--) {
       changeListeners.get(i).onItemChanged(this, item, index, cause);

--- a/app/src/main/java/org/thunderdog/challegram/telegram/UserListManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/telegram/UserListManager.java
@@ -58,23 +58,32 @@ public abstract class UserListManager extends ListManager<Integer> implements Td
 
   @Override
   public void onUserUpdated (TdApi.User user) {
-    runWithUser(user.id, () ->
-      notifyItemChanged(indexOfItem(user.id), REASON_USER_CHANGED)
-    );
+    runWithUser(user.id, () -> {
+      int index = indexOfItem(user.id);
+      if (index != -1) {
+        notifyItemChanged(index, REASON_USER_CHANGED);
+      }
+    });
   }
 
   @Override
   public void onUserFullUpdated (int userId, TdApi.UserFullInfo userFull) {
-    runWithUser(userId, () ->
-      notifyItemChanged(indexOfItem(userId), REASON_USER_FULL_CHANGED)
-    );
+    runWithUser(userId, () -> {
+      int index = indexOfItem(userId);
+      if (index != -1) {
+        notifyItemChanged(index, REASON_USER_FULL_CHANGED);
+      }
+    });
   }
 
   @Override
   public void onUserStatusChanged(int userId, TdApi.UserStatus status, boolean uiOnly) {
-    runWithUser(userId, () ->
-      notifyItemChanged(indexOfItem(userId), REASON_STATUS_CHANGED)
-    );
+    runWithUser(userId, () -> {
+      int index = indexOfItem(userId);
+      if (index != -1) {
+        notifyItemChanged(index, REASON_STATUS_CHANGED);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
Because TDLib sends TdApi.User objects before the actual function result is returned - the app will crash because of non-existing user ID’s at that moment.