### PR TITLE
Fix setStringIfChanged isChanged check

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/ListItem.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/ListItem.java
@@ -432,10 +432,9 @@ public class ListItem {
 
   public boolean setStringIfChanged (@NonNull CharSequence string) {
     if (!StringUtils.equalsOrBothEmpty(this.string, string)) {
-      boolean changed = stringResource == 0 || StringUtils.equalsOrBothEmpty(getString(), string);
       this.string = string;
       this.stringResource = 0;
-      return changed;
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
For now, setStringIfChanged (CharSequence variant) reports that the string resource is 0 or that the equalsOrBothEmpty call is true. 

But:
- equalsOrBothEmpty is called multiple times (!equalsOrBothEmpty in if and equalsOrBothEmpty in if-true which is not needed at all)
- it doesn't handle changes from string -> resource / resource -> string, which leads to not updating items which uses such option (for example, night mode radio buttons hint)