### PR TITLE
Check if the user is not present in the chat before offering adding members

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/ProfileController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/ProfileController.java
@@ -3800,7 +3800,8 @@ public class ProfileController extends ViewController<ProfileController.Args> im
   }
 
   public boolean canAddAnyKindOfMembers () {
-    return tdlib.canInviteUsers(chat) || canBanMembers() || canPromoteMembers(); // FIXME or not?
+    TdApi.ChatMemberStatus status = tdlib.chatStatus(chat.id);
+    return (status != null && status.getConstructor() != TdApi.ChatMemberStatusLeft.CONSTRUCTOR) && (tdlib.canInviteUsers(chat, false) || canBanMembers() || canPromoteMembers()); // FIXME or not?
   }
 
   @Override


### PR DESCRIPTION
I hope Telegram does not allow doing such things (at least it gives an error in normal mode)

Also, the issue is present in Unigram and Telegram for macOS + iOS.