### PR TITLE
[QUICKFIX] Not visible «Add Members» button if group rules allow it but the user is not an admin

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/ProfileController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/ProfileController.java
@@ -3801,7 +3801,7 @@ public class ProfileController extends ViewController<ProfileController.Args> im
 
   public boolean canAddAnyKindOfMembers () {
     TdApi.ChatMemberStatus status = tdlib.chatStatus(chat.id);
-    return (status != null && status.getConstructor() != TdApi.ChatMemberStatusLeft.CONSTRUCTOR) && (tdlib.canInviteUsers(chat, false) || canBanMembers() || canPromoteMembers()); // FIXME or not?
+    return (status != null && status.getConstructor() != TdApi.ChatMemberStatusLeft.CONSTRUCTOR) && (tdlib.canInviteUsers(chat) || canBanMembers() || canPromoteMembers()); // FIXME or not?
   }
 
   @Override


### PR DESCRIPTION
The issue was from the last commit, when «canInviteUsers» call was with allowDefault set to false. This PR reverts the behavior back to normal - which fixes a new bug. But also this PR does not un-fix the initial bug which was fixed before.