### PR TITLE
Fix «YouTube app is not installed» issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,10 @@
   <!--<permission android:name="org.thunderdog.challegram.permission.MAPS_RECEIVE" android:protectionLevel="signature"/>
   <permission android:name="org.thunderdog.challegram.permission.C2D_MESSAGE" android:protectionLevel="signature" />-->
 
+  <queries>
+    <package android:name="com.google.android.youtube" />
+  </queries>
+
   <application
     android:name="org.thunderdog.challegram.BaseApplication"
     android:allowBackup="false"


### PR DESCRIPTION
Android 11+ requires package visibility for apps to be discovered and looks like YouTube SDK doesn’t include the rules: https://developer.android.com/training/package-visibility (Google Maps includes the needed rules, so there are no issues regarding it)