### PR TITLE
Make avatars rounded on Xiaomi

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/config/Device.java
+++ b/app/src/main/java/org/thunderdog/challegram/config/Device.java
@@ -175,7 +175,7 @@ public class Device {
 
   public static final boolean NEED_ADD_KEYBOARD_SIZE = IS_SAMSUNG_SGS_FAMILY;
 
-  public static final boolean ROUND_NOTIFICAITON_IMAGE = MANUFACTURER != XIAOMI;
+  public static final boolean ROUND_NOTIFICAITON_IMAGE = true; //MANUFACTURER != XIAOMI;
 
   public static final boolean FLYME = !StringUtils.isEmpty(Build.DISPLAY) && Build.DISPLAY.toLowerCase().contains("flyme");
 }


### PR DESCRIPTION
Disabled the embedded disabler:
- it only checks for build.prop, so if the MIUI strikes with an issue, AOSP users will still see square avatars
- Android does not round avatars by it's own (until ADAPTIVE_BITMAP is used)
- ADAPTIVE_BITMAP for IconCompat could be used (in fact, it rounds the final Bitmap on every device) - but the avatar will be in the form of the icons