### PR TITLE
Fix music artwork displaying in file picker if artwork is not 1:1 aspect ratio

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/loader/ImageReader.java
+++ b/app/src/main/java/org/thunderdog/challegram/loader/ImageReader.java
@@ -140,6 +140,10 @@ public class ImageReader {
 
     if (bitmap != null) {
       boolean inPurgeable = !file.needBlur() && Config.PIN_BITMAP_ENABLED;
+      
+      if (file.needDecodeSquare()) {
+        bitmap = cropSquare(bitmap);
+      }
 
       if (!file.isWebp() && file.shouldUseBlur() && file.needBlur()) {
         U.blurBitmap(bitmap, file.getBlurRadius(), inPurgeable ? 0 : 1);


### PR DESCRIPTION
This PR fixes a bug introduced by #94, which caused a distorted image shown if the artwork is not square. (Content URI decoding was not cropping to a square by default)

