### PR TITLE
Improve IME + Gestural Navigation popup insets

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/tool/Screen.java
+++ b/app/src/main/java/org/thunderdog/challegram/tool/Screen.java
@@ -235,6 +235,14 @@ public class Screen {
     return navigationBarFrameHeight;
   }
 
+  public static int getNavigationBarFrameDifference () {
+    return Screen.getNavigationBarFrameHeight() - Screen.getNavigationBarHeight();
+  }
+
+  public static boolean needsKeyboardPadding (BaseActivity context) {
+    return context.isKeyboardVisible() && isGesturalNavigationEnabled() && getNavigationBarHeight() > 0;
+  }
+
   public static boolean isGesturalNavigationEnabled () {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       return false;


### PR DESCRIPTION
This PR improves the insets for popups + opened keyboard on Android 10+ introduced by #97 and #101 

- introduces new, proper padding system with filling color under the navigation frame (instead of being above it, leaving it half-transparent)
- fixes the unneeded padding if the navigation bar is hidden (needs testing, only checks resource for now, but should be enough for OneUI and other non-shady OEM's)

Covered and tested all possible in-chat interactions - showSettings, showPopup and showOptions (showSettings has a special layout workaround because simple padding is not enough).