### PR TITLE
Fix AlertDialog message text color on some devices

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/BaseActivity.java
+++ b/app/src/main/java/org/thunderdog/challegram/BaseActivity.java
@@ -571,6 +571,10 @@ public abstract class BaseActivity extends ComponentActivity implements View.OnT
     if (view instanceof TextView)
       ((TextView) view).setTextColor(textColor);
 
+    view = dialog.findViewById(android.R.id.message);
+    if (view instanceof TextView)
+      ((TextView) view).setTextColor(textColor);
+    
     view = Views.tryFindAndroidView(context, dialog, "alertTitle");
     Views.makeFakeBold(view);
     if (view instanceof TextView)


### PR DESCRIPTION
Sometimes, AlertDialog's message can be not themed to the text color. After researching I found, that R.id.message TextView is not explicitly themed (while buttons and title are).

This PR adds the missing setTextColor method call.

Reproduced issue on Sony Xperia 10 Mark 3 w/ Android 11 stock. Can be reproduced by: setting light/dark theme (lightness should be inverted) -> force stopping -> triggering the alert.
Screenshots: https://t.me/c/1112283549/16371 + https://t.me/c/1112283549/16373