### PR TITLE
Fix crash when viewing self restrictions

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/EditRightsController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/EditRightsController.java
@@ -479,7 +479,7 @@ public class EditRightsController extends EditBaseController<EditRightsControlle
               case R.id.btn_date: {
                 boolean canEdit = hasAccessToEditRight(item.getId());
                 view.setIgnoreEnabled(true);
-                view.setEnabled(canEdit || getHintForToggleUnavailability(item.getId(), false) != null);
+                view.setEnabled(canEdit);
                 view.setVisuallyEnabled(canEdit, isUpdate);
                 boolean isDate;
                 if (targetRestrict.restrictedUntilDate == 0) {


### PR DESCRIPTION
This PR fixes a small typo which caused crashes when trying to view restriction for the current account in the chat.

Report: https://t.me/tgandroidtests/217034
Logs: https://t.me/tgandroidtests/217043