### PR TITLE
More bugfixes for Sponsored Messages

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
@@ -772,7 +772,11 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
     if (!Config.SMOOTH_SCROLL_TO_BOTTOM_ENABLED || !smooth) {
       if (adapter.getBottomMessage() != null && adapter.getBottomMessage().isSponsored()) {
         controller.setScrollToBottomVisible(false, false, false);
-        manager.scrollToPositionWithOffset(getHighestSponsoredMessageIndex(), Screen.dp(48f));
+        if (controller.canWriteMessages()) {
+          manager.scrollToPosition(1);
+        } else {
+          manager.scrollToPositionWithOffset(0, Screen.dp(48f));
+        }
       } else {
         manager.scrollToPositionWithOffset(0, 0);
       }
@@ -1140,7 +1144,7 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
           boolean isFirstItemVisible = manager.findFirstCompletelyVisibleItemPosition() == 0;
           adapter.addMessage(SponsoredMessageUtils.sponsoredToTgx(this, loader.getChatId(), lastMessage.getDate(), message), false, false);
           if (isFirstItemVisible && !isScrolling && !controller.canWriteMessages()) {
-            manager.scrollToPositionWithOffset(getHighestSponsoredMessageIndex(), Screen.dp(48f));
+            manager.scrollToPositionWithOffset(0, Screen.dp(48f));
           }
         };
 
@@ -1332,9 +1336,11 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
 
         boolean bottomFullyVisible = manager.findFirstCompletelyVisibleItemPosition() == 0;
         if (!adapter.addMessage(message, false, scrollToBottom)) {
-          if (message.isSponsored()) {
-            if (bottomFullyVisible) {
-              manager.scrollToPositionWithOffset(getHighestSponsoredMessageIndex(), Screen.dp(48f));
+          if (message.isSponsored() && bottomFullyVisible) {
+            if (controller.canWriteMessages()) {
+              manager.scrollToPosition(1);
+            } else {
+              manager.scrollToPositionWithOffset(0, Screen.dp(48f));
             }
           } else {
             manager.scrollToPositionWithOffset(0, scrollOffsetInPixels);
@@ -1346,20 +1352,6 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
     } else if (message.isSending()) {
       loadFromStart();
     }
-  }
-
-  private int getHighestSponsoredMessageIndex () {
-    if (adapter.getItems() == null) {
-      return 0;
-    }
-
-    for (int i = 0; i < adapter.getItems().size(); i++) {
-      if (!adapter.getItem(i).isSponsored()) {
-        return i;
-      }
-    }
-
-    return 0;
   }
 
   @Override


### PR DESCRIPTION
This PR adds another set of fixes and improvements to Sponsored Messages:
- fixed a small typo which broke small bugfix after adding a message
- removed messages looping to find a sponsored message (it is useless for now - because we have only one sponsored message)
- fixed message offsets when opening a channel with not enough content to have scrolling
- fixed message offsets when opening a channel where you are an admin (+ "Scroll to Bottom" fix)