### PR TITLE
Fix scroll offsets for Sponsored Messages

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
@@ -775,7 +775,7 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
         if (controller.canWriteMessages()) {
           manager.scrollToPosition(1);
         } else {
-          manager.scrollToPositionWithOffset(0, Screen.dp(48f));
+          manager.scrollToPositionWithOffset(1, Screen.dp(48f));
         }
       } else {
         manager.scrollToPositionWithOffset(0, 0);
@@ -1144,7 +1144,7 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
           boolean isFirstItemVisible = manager.findFirstCompletelyVisibleItemPosition() == 0;
           adapter.addMessage(SponsoredMessageUtils.sponsoredToTgx(this, loader.getChatId(), lastMessage.getDate(), message), false, false);
           if (isFirstItemVisible && !isScrolling && !controller.canWriteMessages()) {
-            manager.scrollToPositionWithOffset(0, Screen.dp(48f));
+            manager.scrollToPositionWithOffset(1, Screen.dp(48f));
           }
         };
 
@@ -1340,7 +1340,7 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
             if (controller.canWriteMessages()) {
               manager.scrollToPosition(1);
             } else {
-              manager.scrollToPositionWithOffset(0, Screen.dp(48f));
+              manager.scrollToPositionWithOffset(1, Screen.dp(48f));
             }
           } else {
             manager.scrollToPositionWithOffset(0, scrollOffsetInPixels);


### PR DESCRIPTION
This PR fixes a typo which caused invalid behavior for "Scroll to Bottom" and general usage when channel has Sponsored Messages:
- "Scroll to Bottom" was directing to the sponsored message instead of the last real message
- Opening a channel with Sponsored Messages could show it instead of automatically hiding (and revealing through scroll)