### PR TITLE
Modern location alerts: fixed Live Locations cancel behavior

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/component/popups/ModernOptions.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/popups/ModernOptions.java
@@ -42,7 +42,7 @@ public class ModernOptions {
     }
 
     if (shouldShowAlert) {
-      showLocationAlert(context, Lang.getString(isBackground ? R.string.LocationAlertLiveLocation : R.string.LocationAlertLocation), Lang.getString(R.string.LocationAlertLocationDisclaimer), onCancel, onAgree);
+      showLocationAlert(context, Lang.getString(isBackground ? R.string.LocationAlertLiveLocation : R.string.LocationAlertLocation), Lang.getString(R.string.LocationAlertLocationDisclaimer), isBackground ? onCancel : () -> {}, onAgree);
     } else {
       onAgree.run();
     }
@@ -78,11 +78,11 @@ public class ModernOptions {
               onAgree.run();
               break;
             case R.id.btn_privacyPolicy:
-              //onCancel.run();
+              onCancel.run();
               currentController.tdlib().ui().openUrl(currentController, Lang.getStringSecure(R.string.url_privacyPolicy), new TdlibUi.UrlOpenParameters().forceInstantView());
               break;
             case R.id.btn_cancel:
-              //onCancel.run();
+              onCancel.run();
               break;
           }
 


### PR DESCRIPTION
This PR fixes cancelling "Live Locations" alert. Now it properly cancels the following action (like the progress bar) the alert is closed by "Cancel" or "Privacy Policy" buttons.