### PR TITLE
Modify themed icon foreground bounds to match guidelines

### DIFF
--- a/app/src/main/res/drawable/app_adaptive_fg_monochrome.xml
+++ b/app/src/main/res/drawable/app_adaptive_fg_monochrome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="266.99dp"
-    android:height="265.9dp"
+    android:width="108dp"
+    android:height="108dp"
     android:viewportWidth="266.99"
     android:viewportHeight="265.9">
 


### PR DESCRIPTION
> Both layers must be sized at 108 x 108 dp.

Changed only the resulting image width/height, because changing viewport will damage the image.