### PR TITLE
Fix click events on the media item if it is a GIF

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -1105,6 +1105,10 @@ public class MediaCellView extends ViewGroup implements
       tReceiver = imagePreviewReceiver;
     }
 
+    if (media != null && media.isVideo() && media.isGifType() && media.isLoaded() && tReceiver instanceof ImageReceiver && gifReceiver != null) {
+      tReceiver = gifReceiver;
+    }
+
     if (tReceiver.isInsideContent(x, y, media != null ? media.getWidth() : 0, media != null ? media.getHeight() : 0)) {
       if (canTouch(false)) {
         ((MediaView) getParent()).onMediaClick(x, y);


### PR DESCRIPTION
Previously, the code will check for the active receiver. In case of GIF's - it uses preview receiver instead of actual GIF receiver, so coords will never be right.

To not to break other parts of code, I decided to add a check inside onClick function which will take GifReceiver in case it's needed.