### PR TITLE
Support UnsupportedOperationException in IV + auto-toggle details

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/InstantViewController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/InstantViewController.java
@@ -198,8 +198,9 @@ public class InstantViewController extends ViewController<InstantViewController.
           try {
             blocks = PageBlock.parse(this, getUrl(), getArgumentsStrict().instantView, pageBlock, this, null);
           } catch (Throwable t) {
-            Log.e("Unsupported instant view block", t);
-            context().tooltipManager().builder(view).show(tdlib, R.string.InstantViewError).hideDelayed();
+            Log.e("Exception in instant view block", t);
+            context().tooltipManager().builder(view).show(tdlib, t instanceof UnsupportedOperationException ? R.string.InstantViewSectionUnsupported : R.string.InstantViewError).hideDelayed();
+            ((PageBlockRichText) pageBlock).toggleDetailsOpened();
             return;
           }
           ListItem[] items = new ListItem[blocks.size()];

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3123,6 +3123,7 @@
 
   <string name="InstantViewUnsupported">Instant View for this page is not yet supported.</string>
   <string name="InstantViewError">Instant View could not be displayed due to an error.</string>
+  <string name="InstantViewSectionUnsupported">Instant View for this section is not yet supported.</string>
   <string name="LanguageDatabase">Localizations</string>
   <string name="SettingsAndThemes">Settings and Themes</string>
 


### PR DESCRIPTION
This PR adds a separate string to show if expanding details of an IV section causes an unsupported exception (for example, if it contains tables).

Also, the triangle will also collapse back to the original state.