### PR TITLE
Fix crashing on empty adapter list on ChatLinksController

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/ChatLinksController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/ChatLinksController.java
@@ -285,6 +285,7 @@ public class ChatLinksController extends RecyclerViewController<ChatLinksControl
     RemoveHelper.attach(recyclerView, new RemoveHelper.Callback() {
       @Override
       public boolean canRemove (RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, int position) {
+        if (adapter.getItems().isEmpty()) return false;
         ListItem item = (ListItem) adapter.getItems().get(position);
         return item != null && item.getId() == R.id.btn_inviteLink;
       }


### PR DESCRIPTION
This PR fixes a crash when trying to touch anything + adapter is empty in ChatLinksController (for example, when opening this screen with a bad internet connection or without it at all)