### PR TITLE
Chat mark is now affecting author’s maxWidth

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessage.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessage.java
@@ -2630,10 +2630,12 @@ public abstract class TGMessage implements MultipleViewProvider.InvalidateConten
         authorName = sender.getName();
       }
       if (needName(true) && maxWidth > 0) {
-        hAuthorNameT = makeName(authorName, !(forceForwardedInfo() && forwardInfo instanceof TGSourceHidden), isPsa, !needName(false), msg.forwardInfo == null || forceForwardedInfo() ? msg.viaBotUserId : 0, maxWidth, false);
         if (!forceForwardedInfo() && sender.hasChatMark()) {
           hAuthorChatMark = makeChatMark(maxWidth);
+          maxWidth -= hAuthorChatMark.getWidth();
         }
+
+        hAuthorNameT = makeName(authorName, !(forceForwardedInfo() && forwardInfo instanceof TGSourceHidden), isPsa, !needName(false), msg.forwardInfo == null || forceForwardedInfo() ? msg.viaBotUserId : 0, maxWidth, false);
       } else {
         hAuthorNameT = null;
         hAuthorChatMark = null;


### PR DESCRIPTION
This PR improves logic of chat marks inside TGMessage's header, modifying maxWidth when a chat mark is added. This fixes chat mark overlapping or going outside the edge of a bubble.