### PR TITLE
Faster navigation between search results [UX]

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
@@ -2217,6 +2217,10 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
     searchManager.moveToNext(next);
   }
 
+  public void moveToNextResult (boolean next, int byHowMuch) {
+    searchManager.moveToNext(next, byHowMuch);
+  }
+
   // Delegate
 
   public int getRecyclerHeight () {

--- a/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
@@ -109,6 +109,7 @@ import org.thunderdog.challegram.component.chat.MessagesAdapter;
 import org.thunderdog.challegram.component.chat.MessagesHolder;
 import org.thunderdog.challegram.component.chat.MessagesLayout;
 import org.thunderdog.challegram.component.chat.MessagesManager;
+import org.thunderdog.challegram.component.chat.MessagesSearchManager;
 import org.thunderdog.challegram.component.chat.PinnedMessagesBar;
 import org.thunderdog.challegram.component.chat.RaiseHelper;
 import org.thunderdog.challegram.component.chat.ReplyView;
@@ -2514,7 +2515,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
     forceHideToast();
     topBar.hideAll(false);
 
-    resetSearhControls();
+    resetSearchControls();
 
     tdlib.ui().updateTTLButton(R.id.menu_secretChat, headerView, chat, true);
     messagesView.setMessageAnimatorEnabled(false);
@@ -3877,7 +3878,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
 
     cancelJumpToDate();
     cancelAdminsRequest();
-    resetSearhControls();
+    resetSearchControls();
     triggerOneShot = true;
 
     if (manager != null) {
@@ -9940,6 +9941,19 @@ public class MessagesController extends ViewController<MessagesController.Argume
         }
       }
     };
+    final View.OnLongClickListener onLongClickListener = v -> {
+      switch (v.getId()) {
+        case R.id.btn_search_prev: {
+          manager.moveToNextResult(false, MessagesSearchManager.SEARCH_LOAD_LIMIT);
+          break;
+        }
+        case R.id.btn_search_next: {
+          manager.moveToNextResult(true, MessagesSearchManager.SEARCH_LOAD_LIMIT);
+          break;
+        }
+      }
+      return true;
+    };
 
     Context context = context();
 
@@ -9994,6 +10008,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
     searchNextButton = Views.newImageButton(context, R.drawable.baseline_keyboard_arrow_up_24, R.id.theme_color_icon, this);
     searchNextButton.setId(R.id.btn_search_next);
     searchNextButton.setOnClickListener(onClickListener);
+    searchNextButton.setOnLongClickListener(onLongClickListener);
     searchNextButton.setLayoutParams(fp);
     searchNextButton.setEnabled(false);
     searchControlsLayout.addView(searchNextButton);
@@ -10002,6 +10017,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
     searchPrevButton = Views.newImageButton(context, R.drawable.baseline_keyboard_arrow_down_24, R.id.theme_color_icon, this);
     searchPrevButton.setId(R.id.btn_search_prev);
     searchPrevButton.setOnClickListener(onClickListener);
+    searchPrevButton.setOnLongClickListener(onLongClickListener);
     searchPrevButton.setPadding(0, 0, Screen.dp(12f), 0);
     searchPrevButton.setLayoutParams(fp);
     searchPrevButton.setEnabled(false);
@@ -10045,7 +10061,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
 
   private boolean searchControlsForChannel;
 
-  private void resetSearhControls () {
+  private void resetSearchControls() {
     if (searchControlsLayout != null) {
       searchCounterView.setText("");
       searchPrevButton.setEnabled(false);
@@ -10216,7 +10232,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
   public void onChatSearchFinished (String counter, int index, int totalCount) {
     lastSearchIndex = index;
     lastSearchTotalCount = totalCount;
-    searchNextButton.setEnabled(index < totalCount);
+    searchNextButton.setEnabled(index < totalCount - 1);
     searchPrevButton.setEnabled(index > 0);
     searchCounterView.setText(counter);
     setSearchInProgress(false, true);


### PR DESCRIPTION
## The problem

I have a private channel with tons of music, and when I type an artist name it gives me about 100-300 search results, which requires a lot of time to jump to the first result in the list.

<img src="https://user-images.githubusercontent.com/7825871/174486916-5aac2093-2f64-4319-b022-e129a7412355.jpg" width="30%"/>

## The solution

What I suggest, is to navigate between search results much faster by long clicking on "up" or "down" buttons. I came across the source code and found that TGX uses 20 messages per 1 page, so I decided to use this value as a constant.