### PR TITLE
Chat Marks: max width improvements

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessage.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessage.java
@@ -645,7 +645,7 @@ public abstract class TGMessage implements MultipleViewProvider.InvalidateConten
   }
 
   private int getAuthorWidth () {
-    return hAuthorNameT != null ? hAuthorNameT.getWidth() + (hAuthorChatMark != null ? hAuthorChatMark.getWidth() + Screen.dp(8f) : 0) : needName(true) ? -Screen.dp(3f) : 0;
+    return hAuthorNameT != null ? hAuthorNameT.getWidth() + (hAuthorChatMark != null ? hAuthorChatMark.getWidth() + Screen.dp(16f) : 0) : needName(true) ? -Screen.dp(3f) : 0;
   }
 
   private int computeBubbleWidth () {
@@ -2695,10 +2695,12 @@ public abstract class TGMessage implements MultipleViewProvider.InvalidateConten
       nameMaxWidth = max;
     }
     if (nameMaxWidth > 0) {
-      hAuthorNameT = makeName(authorName, !(forceForwardedInfo() && forwardInfo instanceof TGSourceHidden), isPsa, !needName(false), msg.forwardInfo == null || forceForwardedInfo() ? msg.viaBotUserId : 0, nameMaxWidth, false);
       if (!forceForwardedInfo() && sender.hasChatMark()) {
         hAuthorChatMark = makeChatMark(totalMaxWidth);
+        nameMaxWidth -= hAuthorChatMark.getWidth() + Screen.dp(8f);
       }
+
+      hAuthorNameT = makeName(authorName, !(forceForwardedInfo() && forwardInfo instanceof TGSourceHidden), isPsa, !needName(false), msg.forwardInfo == null || forceForwardedInfo() ? msg.viaBotUserId : 0, nameMaxWidth, false);
     } else {
       hAuthorNameT = null;
       hAuthorChatMark = null;


### PR DESCRIPTION
This PR fixes Chat Marks affecting text max width in bubbles.

Tested on very long usernames in both bubble and flat modes (chat + channels).