### PR TITLE
Implement spoilerless pinned message showing

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/core/Lang.java
+++ b/app/src/main/java/org/thunderdog/challegram/core/Lang.java
@@ -1004,7 +1004,7 @@ public class Lang {
         return Lang.getString(R.string.PinnedMessageChanged);
       }
     }
-    String text = TD.getTextFromMessage(message);
+    String text = TD.getTextFromMessageSpoilerless(message);
     if (!needPerson) {
       if (StringUtils.isEmpty(text))
         text = Lang.lowercase(TD.buildShortPreview(tdlib, message, true));

--- a/app/src/main/java/org/thunderdog/challegram/data/TD.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TD.java
@@ -3951,6 +3951,10 @@ public class TD {
     return msg != null ? getTextFromMessage(msg.content) : null;
   }
 
+  public static String getTextFromMessageSpoilerless (TdApi.Message msg) {
+    return msg != null ? getTextFromMessageSpoilerless(msg.content) : null;
+  }
+
   public static boolean suggestSharingContact (TdApi.User user) {
     return false; // TODO?
   }
@@ -4023,6 +4027,11 @@ public class TD {
   public static String getTextFromMessage (TdApi.MessageContent content) {
     TdApi.FormattedText formattedText = Td.textOrCaption(content);
     return formattedText != null ? formattedText.text : null;
+  }
+
+  public static String getTextFromMessageSpoilerless (TdApi.MessageContent content) {
+    TdApi.FormattedText formattedText = Td.textOrCaption(content);
+    return formattedText != null ? TD.toCharSequence(formattedText, false, false).toString() : null;
   }
 
   public static @TdApi.MessageContent.Constructors int convertToMessageContent (TdApi.WebPage webPage) {

--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessageChat.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessageChat.java
@@ -643,7 +643,7 @@ public class TGMessageChat extends TGMessage implements Client.ResultHandler {
           break;
         }
 
-        String text = TD.getTextFromMessage(otherMessage);
+        String text = TD.getTextFromMessageSpoilerless(otherMessage);
         if (!StringUtils.isEmpty(text)) {
           text = Strings.replaceNewLines(Strings.limit(text, 20));
         }


### PR DESCRIPTION
This PR fixes viewing spoiler formatting in "X pinned Y" (Y will be now replaced with replacement char if it's a spoiler). 

Fixed in notifications and in-app (service message).