### PR TITLE
Fix: Bubble width with long inline keyboards

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessage.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessage.java
@@ -2897,6 +2897,10 @@ public abstract class TGMessage implements MultipleViewProvider.InvalidateConten
       final int bubblePaddingBottom = getBubblePaddingBottom();
 
       bubbleWidth += bubblePaddingLeft + bubblePaddingRight;
+      if (inlineKeyboard != null && bubbleWidth < inlineKeyboard.getWidth()) {
+        bubbleWidth = inlineKeyboard.getWidth();
+      }
+
       bubbleHeight += bubblePaddingTop + bubblePaddingBottom;
 
       int leftContentEdge = centerBubble() ? width / 2 - bubbleWidth / 2 : computeBubbleLeft();


### PR DESCRIPTION
## Description
In this pull request I've included a fix (that can also be considered as an improvement) to the size of the message bubbles, that can be **smaller than the inline keyboard** in some situations.

## Details
- This change will require tests with different sizes and types of bubble content and inline keyboards, to ensure that everything is working correctly.
- Also, in some situations (like the first example below), the size of the bubble could look controversial due to the big empty space (but I **personally** like it).

## Screenshots: example 1

**Old behavior:**

![Old behavior](https://user-images.githubusercontent.com/58666938/180615912-7afd4e86-a662-451c-be83-f085b5da5680.png)
**New behavior:**

![New behavior](https://user-images.githubusercontent.com/58666938/180615916-3e705871-cd4a-4e44-a37e-c0a9327a5811.png)

## Screenshots: example 2

**Old behavior:**

![Old behavior (2)](https://user-images.githubusercontent.com/58666938/180616683-5d608e4f-af8e-4ac8-974f-ddc673abe788.png)
**New behavior:**

![New behavior (2)](https://user-images.githubusercontent.com/58666938/180616700-24d2b157-b803-43b2-b510-818b61dca456.png)

If you have any **suggestion** to improve this (**or if you just want to tell if you like this change or not**), write in the comments of this PR or in [@tgx_dev](https://t.me/tgx_dev).