### PR TITLE
Fix monochrome icon on One UI (Android 13+)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -453,6 +453,6 @@
 
     <meta-data
       android:name="com.samsung.android.icon_container.has_icon_container"
-      android:value="true" />
+      android:value="@bool/com_samsung_android_icon_container_has_icon_container"/>
   </application>
 </manifest>

--- a/app/src/main/res/values-v33/values.xml
+++ b/app/src/main/res/values-v33/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="com_samsung_android_icon_container_has_icon_container">false</bool>
+</resources>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -2,4 +2,5 @@
 <resources>
   <bool name="isTablet">false</bool>
   <bool name="isNight">false</bool>
+  <bool name="com_samsung_android_icon_container_has_icon_container">true</bool>
 </resources>


### PR DESCRIPTION
Fixes #281
![screenshot](https://user-images.githubusercontent.com/4970595/208149671-37e30b13-a620-4018-b29c-b4444e03bfe5.png)
