### PR TITLE
Full-screen media viewer 2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -223,6 +223,9 @@ dependencies {
   // ZXing: https://github.com/zxing/zxing/blob/master/CHANGES
   implementation("com.google.zxing:core:3.4.1")
 
+  // subsampling-scale-image-view: https://github.com/davemorrissey/subsampling-scale-image-view
+  implementation("com.davemorrissey.labs:subsampling-scale-image-view:3.10.0")
+
   // YouTube: https://developers.google.com/youtube/android/player/
   implementation(files("thirdparty/YouTubeAndroidPlayerApi.jar"))
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -224,7 +224,7 @@ dependencies {
   implementation("com.google.zxing:core:3.4.1")
 
   // subsampling-scale-image-view: https://github.com/davemorrissey/subsampling-scale-image-view
-  implementation("com.davemorrissey.labs:subsampling-scale-image-view:3.10.0")
+  implementation("com.davemorrissey.labs:subsampling-scale-image-view-androidx:3.10.0")
 
   // YouTube: https://developers.google.com/youtube/android/player/
   implementation(files("thirdparty/YouTubeAndroidPlayerApi.jar"))

--- a/app/src/main/java/org/thunderdog/challegram/U.java
+++ b/app/src/main/java/org/thunderdog/challegram/U.java
@@ -1323,6 +1323,10 @@ public class U {
     public long getDuration (TimeUnit unit) {
       return unit.convert(durationMs, TimeUnit.MILLISECONDS);
     }
+
+    public boolean isRotated () {
+      return U.isExifRotated(rotation);
+    }
   }
 
   @Nullable

--- a/app/src/main/java/org/thunderdog/challegram/component/attach/MediaBottomGalleryController.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/attach/MediaBottomGalleryController.java
@@ -568,7 +568,7 @@ public class MediaBottomGalleryController extends MediaBottomBaseController<Medi
   private final MediaViewThumbLocation location = new MediaViewThumbLocation();
 
   @Override
-  public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
+  public MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item) {
     if (MediaItem.isGalleryType(item.getType()) && !mediaLayout.isHidden()) {
       View view = adapter.findViewForImage(item.getSourceGalleryFile(), (LinearLayoutManager) getLayoutManager());
       if (view != null) {

--- a/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
@@ -2048,6 +2048,8 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
     MediaStack stack;
     stack = new MediaStack(controller.context(), tdlib);
     stack.set(addedAfter.get(), result);
+    stack.setReverseModeHint(false);
+    stack.setForceThumbsHint(false);
 
     return stack;
   }

--- a/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
+++ b/app/src/main/java/org/thunderdog/challegram/component/chat/MessagesManager.java
@@ -73,6 +73,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import me.vkryl.core.ArrayUtils;
@@ -2016,28 +2017,23 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
     }
 
     final ArrayList<MediaItem> result = new ArrayList<>();
-    final boolean needGifs = filter != null && filter.getConstructor() == TdApi.SearchMessagesFilterAnimation.CONSTRUCTOR;
 
-    final boolean[] found = new boolean[1];
-    final int[] addedAfter = new int[1];
+    AtomicBoolean found = new AtomicBoolean();
+    AtomicInteger addedAfter = new AtomicInteger();
 
     RunnableData<TdApi.Message> callback = message -> {
       if (TD.isSecret(message))
         return;
-      MediaItem item;
-      if (needGifs) {
-        item = message.content.getConstructor() == TdApi.MessageAnimation.CONSTRUCTOR ? MediaItem.valueOf(controller.context(), tdlib, message) : null;
-      } else {
-        item = message.content.getConstructor() == TdApi.MessagePhoto.CONSTRUCTOR || message.content.getConstructor() == TdApi.MessageVideo.CONSTRUCTOR ? MediaItem.valueOf(controller.context(), tdlib, message) : null;
-      }
+      boolean matchesFilter = filter == null || Td.matchesFilter(message, filter);
+      MediaItem item = matchesFilter ? MediaItem.valueOf(controller.context(), tdlib, message) : null;
       if (item != null) {
         result.add(0, item);
-        if (found[0]) {
-          addedAfter[0]++;
+        if (found.get()) {
+          addedAfter.incrementAndGet();
         }
-      }
-      if (!found[0] && message.id == fromMessageId) {
-        found[0] = true;
+        if (message.id == fromMessageId) {
+          found.set(true);
+        }
       }
     };
 
@@ -2045,13 +2041,13 @@ public class MessagesManager implements Client.ResultHandler, MessagesSearchMana
       parsedMessage.iterate(callback, true);
     }
 
-    if (!found[0]) {
+    if (!found.get()) {
       return null;
     }
 
     MediaStack stack;
     stack = new MediaStack(controller.context(), tdlib);
-    stack.set(addedAfter[0], result);
+    stack.set(addedAfter.get(), result);
 
     return stack;
   }

--- a/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
@@ -153,10 +153,10 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
     this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_FILE, hasPreview && TGMimeType.isImageMimeType(doc.mimeType), context.getChatId(), context.getId());
     this.progress.setBackgroundColorProvider(context);
     this.progress.setSimpleListener(this);
+    this.progress.setDocumentMetadata(doc, !hasPreview);
     if (hasPreview) {
       this.progress.setBackgroundColor(0x44000000);
     } else {
-      this.progress.setDownloadedIconRes(doc);
       this.progress.setBackgroundColorId(TD.getFileColorId(doc, context.isOutgoingBubble()));
     }
     this.progress.setFile(doc.document, context.getMessage());

--- a/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
@@ -38,6 +38,7 @@ import org.thunderdog.challegram.loader.ImageMp3File;
 import org.thunderdog.challegram.loader.ImageReceiver;
 import org.thunderdog.challegram.loader.ImageVideoThumbFile;
 import org.thunderdog.challegram.loader.Receiver;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
 import org.thunderdog.challegram.player.TGPlayerController;
 import org.thunderdog.challegram.telegram.TGLegacyAudioManager;
 import org.thunderdog.challegram.telegram.Tdlib;
@@ -632,6 +633,25 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
   }
 
   private int lastStartX, lastStartY;
+
+  public MediaViewThumbLocation getMediaThumbLocation (View view, int viewTop, int viewBottom, int top) {
+    if (hasPreview) {
+      MediaViewThumbLocation thumbLocation = new MediaViewThumbLocation();
+      thumbLocation.setNoBounce();
+
+      final int previewSize = getPreviewSize();
+
+      int actualTop = lastStartY + viewTop;
+      int actualBottom = (view.getMeasuredHeight() - (lastStartY + previewSize)) + viewBottom;
+
+      thumbLocation.set(lastStartX, lastStartY + top, lastStartX + previewSize, lastStartY + previewSize + top);
+      thumbLocation.setClip(0, actualTop < 0 ? -actualTop : 0, 0, actualBottom < 0 ? -actualBottom : 0);
+      thumbLocation.setRoundings(previewSize / 2);
+
+      return thumbLocation;
+    }
+    return null;
+  }
 
   public <T extends View & DrawableProvider> void draw (T view, Canvas c, int startX, int startY, Receiver preview, Receiver receiver, @ColorInt int backgroundColor, int contentReplaceColor, float alpha, float checkFactor) {
     this.lastStartX = startX;

--- a/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
@@ -15,6 +15,7 @@
 package org.thunderdog.challegram.data;
 
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.os.SystemClock;
 import android.view.MotionEvent;
 import android.view.View;
@@ -79,6 +80,7 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
 
   public boolean hasPreview;
   public ImageFile miniThumbnail, preview, fullPreview;
+  private boolean mayBeTransparent;
 
   private @Nullable String title;
   private boolean needFakeTitle;
@@ -436,6 +438,7 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
   private ImageFile createFullPreview () {
     if (fullPreview == null) {
       if (doc != null) {
+        mayBeTransparent = TGMimeType.isTransparentImageMimeType(doc.mimeType);
         fullPreview = createFullPreview(context.tdlib(), doc);
       } else if (audio != null && TD.isFileLoaded(audio.audio) && (audio.albumCoverThumbnail == null || preview == null || Math.max(audio.albumCoverThumbnail.width, audio.albumCoverThumbnail.height) < 90)) {
         fullPreview = new ImageMp3File(audio.audio.local.path);
@@ -673,6 +676,9 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
       }*/
       preview.setPaintAlpha(alpha * preview.getAlpha());
       receiver.setPaintAlpha(alpha * receiver.getAlpha());
+      if (mayBeTransparent) {
+        receiver.drawPlaceholderRounded(c, previewSize / 2f, ColorUtils.alphaColor(alpha, Color.WHITE));
+      }
       DrawAlgorithms.drawReceiver(c, preview, receiver, true, true, startX, startY, startX + previewSize, startY + previewSize);
       receiver.restorePaintAlpha();
       preview.restorePaintAlpha();

--- a/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/FileComponent.java
@@ -91,6 +91,7 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
   private float sizeWidth;
 
   private final TGMessage context;
+  private final TdApi.Message message;
 
   // DOCUMENT
 
@@ -98,8 +99,9 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
     return needOpenIn;
   }
 
-  public FileComponent (@NonNull TGMessage context, @NonNull TdApi.Document doc) {
+  public FileComponent (@NonNull TGMessage context, @NonNull TdApi.Message message, @NonNull TdApi.Document doc) {
     this.context = context;
+    this.message = message;
     if (this.needOpenIn = TD.isSupportedMusic(doc)) {
       // TdApi.VoiceNote fakeAudio = new TdApi.VoiceNote(0, null, doc.mimeType, doc.document);
       // setVoice(fakeAudio, null, null);
@@ -153,7 +155,7 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
       }
     }
 
-    this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_FILE, hasPreview && TGMimeType.isImageMimeType(doc.mimeType), context.getChatId(), context.getId());
+    this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_FILE, hasPreview && TGMimeType.isImageMimeType(doc.mimeType), message != null ? message.chatId : context.getChatId(), message != null ? message.id : context.getId());
     this.progress.setBackgroundColorProvider(context);
     this.progress.setSimpleListener(this);
     this.progress.setDocumentMetadata(doc, !hasPreview);
@@ -170,8 +172,9 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
 
   // AUDIO
 
-  public FileComponent (@NonNull TGMessage context, @NonNull TdApi.Audio audio, TdApi.Message playPauseFile, TGPlayerController.PlayListBuilder playListBuilder) {
+  public FileComponent (@NonNull TGMessage context, @NonNull TdApi.Message message, @NonNull TdApi.Audio audio, TdApi.Message playPauseFile, TGPlayerController.PlayListBuilder playListBuilder) {
     this.context = context;
+    this.message = message;
 
     setAudio(audio, playPauseFile, playListBuilder);
   }
@@ -204,7 +207,7 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
       }
     }
 
-    this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_MUSIC, preview != null, context.getChatId(), context.getId());
+    this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_MUSIC, preview != null, message != null ? message.chatId : context.getChatId(), message != null ? message.id : context.getId());
     this.progress.setBackgroundColorProvider(context);
     this.progress.setSimpleListener(this);
     if (hasPreview) {
@@ -222,8 +225,9 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
 
   private float unreadFactor;
 
-  public FileComponent (@NonNull TGMessage context, @NonNull TdApi.VoiceNote voice, TdApi.Message playPauseFile, TGPlayerController.PlayListBuilder playListBuilder) {
+  public FileComponent (@NonNull TGMessage context, @NonNull TdApi.Message message, @NonNull TdApi.VoiceNote voice, TdApi.Message playPauseFile, TGPlayerController.PlayListBuilder playListBuilder) {
     this.context = context;
+    this.message = message;
 
     setVoice(voice, playPauseFile, playListBuilder);
   }
@@ -235,7 +239,7 @@ public class FileComponent extends BaseComponent implements FileProgressComponen
     this.waveform = new Waveform(voice.waveform, Waveform.MODE_BITMAP, context.isOutgoingBubble());
     this.unreadFactor = playPauseFile != context.getMessage() || context.isContentRead() ? 0f : 1f;
 
-    this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_VOICE, false, context.getChatId(), context.getId());
+    this.progress = new FileProgressComponent(context.context(), context.tdlib(), TdlibFilesManager.DOWNLOAD_FLAG_VOICE, false,message != null ? message.chatId : context.getChatId(), message != null ? message.id : context.getId());
     this.progress.setBackgroundColorProvider(context);
     this.progress.setSimpleListener(this);
     this.progress.setBackgroundColorId(context.isOutgoingBubble() ? R.id.theme_color_bubbleOut_file : R.id.theme_color_file);

--- a/app/src/main/java/org/thunderdog/challegram/data/InlineResult.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/InlineResult.java
@@ -30,6 +30,8 @@ import org.thunderdog.challegram.component.inline.CustomResultView;
 import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.emoji.Emoji;
 import org.thunderdog.challegram.loader.ComplexReceiver;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
+import org.thunderdog.challegram.mediaview.data.MediaItem;
 import org.thunderdog.challegram.player.TGPlayerController;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.theme.Theme;
@@ -388,6 +390,10 @@ public abstract class InlineResult <T> implements MessageSourceProvider {
   protected void drawInternal (CustomResultView view, Canvas c, ComplexReceiver receiver, int viewWidth, int viewHeight, int startY) { }
 
   public boolean onTouchEvent (View view, MotionEvent e) {
+    return false;
+  }
+
+  public boolean setThumbLocation (MediaViewThumbLocation location, View view, int index, MediaItem mediaItem) {
     return false;
   }
 

--- a/app/src/main/java/org/thunderdog/challegram/data/InlineResultCommon.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/InlineResultCommon.java
@@ -18,7 +18,6 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
-import android.provider.MediaStore;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -26,7 +25,6 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.drinkless.td.libcore.telegram.Client;
 import org.drinkless.td.libcore.telegram.TdApi;
 import org.thunderdog.challegram.BaseActivity;
 import org.thunderdog.challegram.R;
@@ -40,7 +38,6 @@ import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.loader.ComplexReceiver;
 import org.thunderdog.challegram.loader.ImageFile;
 import org.thunderdog.challegram.loader.ImageFileLocal;
-import org.thunderdog.challegram.loader.ImageFileRemote;
 import org.thunderdog.challegram.player.TGPlayerController;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.telegram.TdlibFilesManager;
@@ -50,7 +47,6 @@ import org.thunderdog.challegram.tool.Drawables;
 import org.thunderdog.challegram.tool.Paints;
 import org.thunderdog.challegram.tool.Screen;
 import org.thunderdog.challegram.tool.Strings;
-import org.thunderdog.challegram.tool.UI;
 import org.thunderdog.challegram.util.text.Letters;
 import org.thunderdog.challegram.util.text.Text;
 import org.thunderdog.challegram.util.text.TextColorSets;
@@ -440,8 +436,8 @@ public class InlineResultCommon extends InlineResult<TdApi.InlineQueryResult> im
     this.fileProgress = new FileProgressComponent(context, tdlib, TdlibFilesManager.DOWNLOAD_FLAG_FILE, getMediaPreview() != null, message.chatId, message.id);
     this.fileProgress.setViewProvider(currentViews);
     this.fileProgress.setSimpleListener(this);
+    this.fileProgress.setDocumentMetadata(document, this.getMediaPreview() == null);
     if (this.getMediaPreview() == null) {
-      this.fileProgress.setDownloadedIconRes(document);
       this.fileProgress.setBackgroundColorId(TD.getFileColorId(document, false));
     } else {
       this.fileProgress.setBackgroundColor(0x44000000);
@@ -471,8 +467,8 @@ public class InlineResultCommon extends InlineResult<TdApi.InlineQueryResult> im
       this.fileProgress.setSimpleListener(this);
     }
     this.fileProgress.setPausedIconRes(R.drawable.baseline_insert_drive_file_24);
+    this.fileProgress.setDocumentMetadata(data.document, this.getMediaPreview() == null);
     if (this.getMediaPreview() == null) {
-      this.fileProgress.setDownloadedIconRes(data.document);
       this.fileProgress.setBackgroundColorId(TD.getFileColorId(data.document, false));
     } else {
       this.fileProgress.setBackgroundColor(0x44000000);

--- a/app/src/main/java/org/thunderdog/challegram/data/InlineResultCommon.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/InlineResultCommon.java
@@ -38,6 +38,8 @@ import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.loader.ComplexReceiver;
 import org.thunderdog.challegram.loader.ImageFile;
 import org.thunderdog.challegram.loader.ImageFileLocal;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
+import org.thunderdog.challegram.mediaview.data.MediaItem;
 import org.thunderdog.challegram.player.TGPlayerController;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.telegram.TdlibFilesManager;
@@ -246,6 +248,22 @@ public class InlineResultCommon extends InlineResult<TdApi.InlineQueryResult> im
   @Override
   public void onFactorChangeFinished (int id, float finalFactor, FactorAnimator callee) {
 
+  }
+
+  @Override
+  public boolean setThumbLocation (MediaViewThumbLocation location, View view, int index, MediaItem mediaItem) {
+    RectF rectF = Paints.getRectF();
+    rectF.set(Screen.dp(11f), getPaddingVertical(), Screen.dp(11f) + Screen.dp(50f), view.getMeasuredHeight() - getPaddingVertical());
+
+    // location.clipTop -= rectF.top;
+    location.left += rectF.left;
+    location.top += rectF.top;
+    location.right = location.left + (int) rectF.width();
+    location.bottom = location.top + (int) rectF.height();
+    location.setClip(0, 0, 0, 0);
+    location.setRoundings((int) (rectF.width() / 2f));
+
+    return getMediaPreview() != null;
   }
 
   public String getTrackTitle () {

--- a/app/src/main/java/org/thunderdog/challegram/data/PageBlockMedia.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/PageBlockMedia.java
@@ -598,10 +598,10 @@ public class PageBlockMedia extends PageBlock implements MediaWrapper.OnClickLis
   }
 
   @Override
-  public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
+  public MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item) {
     MediaWrapper wrapper;
     if (isList || collageContext != null) {
-      wrapper = getWrapper(index);
+      wrapper = getWrapper(indexInStack);
     } else {
       wrapper = this.wrapper;
     }

--- a/app/src/main/java/org/thunderdog/challegram/data/TD.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TD.java
@@ -1296,6 +1296,33 @@ public class TD {
     }
   }
 
+  public static TdApi.Video convertToVideo (TdApi.Document document, @Nullable BitmapFactory.Options options, boolean isRotated) {
+    int width, height;
+    if (options != null && Math.min(options.outWidth, options.outHeight) > 0) {
+      if (isRotated) {
+        //noinspection SuspiciousNameCombination
+        width = options.outHeight; height = options.outWidth;
+      } else {
+        width = options.outWidth;  height = options.outHeight;
+      }
+    } else if (document.thumbnail != null) {
+      width = document.thumbnail.width;
+      height = document.thumbnail.height;
+      float scale = 2f;
+      width *= scale;
+      height *= scale;
+    } else {
+      width = height = 0;
+    }
+    return new TdApi.Video(
+      0, width, height,
+      document.fileName, document.mimeType,
+      false, true,
+      document.minithumbnail, document.thumbnail,
+      document.document
+    );
+  }
+
   public static TdApi.Photo convertToPhoto (TdApi.Document document, @Nullable BitmapFactory.Options options, boolean isRotated) {
     int width, height;
     if (options != null && Math.min(options.outWidth, options.outHeight) > 0) {

--- a/app/src/main/java/org/thunderdog/challegram/data/TD.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TD.java
@@ -21,6 +21,7 @@ import android.app.DownloadManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
+import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
@@ -1293,6 +1294,33 @@ public class TD {
         return null;
       }
     }
+  }
+
+  public static TdApi.Photo convertToPhoto (TdApi.Document document, @Nullable BitmapFactory.Options options, boolean isRotated) {
+    int width, height;
+    if (options != null && Math.min(options.outWidth, options.outHeight) > 0) {
+      if (isRotated) {
+        //noinspection SuspiciousNameCombination
+        width = options.outHeight; height = options.outWidth;
+      } else {
+        width = options.outWidth;  height = options.outHeight;
+      }
+    } else if (document.thumbnail != null) {
+      width = document.thumbnail.width;
+      height = document.thumbnail.height;
+    } else {
+      width = height = 0;
+    }
+    TdApi.PhotoSize thumbnailSize = toThumbnailSize(document.thumbnail);
+    TdApi.PhotoSize[] sizes = new TdApi.PhotoSize[thumbnailSize != null ? 2 : 1];
+    TdApi.PhotoSize targetSize = new TdApi.PhotoSize("w", document.document, width, height, null);
+    if (thumbnailSize != null) {
+      sizes[0] = thumbnailSize;
+      sizes[1] = targetSize;
+    } else {
+      sizes[0] = targetSize;
+    }
+    return new TdApi.Photo(false, null, sizes);
   }
 
   public static TdApi.Photo convertToPhoto (TdApi.Sticker sticker) {

--- a/app/src/main/java/org/thunderdog/challegram/data/TD.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TD.java
@@ -1308,6 +1308,9 @@ public class TD {
     } else if (document.thumbnail != null) {
       width = document.thumbnail.width;
       height = document.thumbnail.height;
+      float scale = 2f;
+      width *= scale;
+      height *= scale;
     } else {
       width = height = 0;
     }

--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessageFile.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessageFile.java
@@ -32,6 +32,7 @@ import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.loader.ComplexReceiver;
 import org.thunderdog.challegram.loader.DoubleImageReceiver;
 import org.thunderdog.challegram.loader.ImageReceiver;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
 import org.thunderdog.challegram.theme.Theme;
 import org.thunderdog.challegram.tool.DrawAlgorithms;
 import org.thunderdog.challegram.tool.Paints;
@@ -672,6 +673,16 @@ public class TGMessageFile extends TGMessage {
       }
     }
     return res;
+  }
+
+  @Override
+  public MediaViewThumbLocation getMediaThumbLocation (long messageId, View view, int viewTop, int viewBottom, int top) {
+    for (ListAnimator.Entry<CaptionedFile> entry : files) {
+      if (entry.item.messageId == messageId) {
+        return entry.item.component.getMediaThumbLocation(view, viewTop, viewBottom, top);
+      }
+    }
+    return null;
   }
 
   // Document actions

--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessageFile.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessageFile.java
@@ -253,19 +253,19 @@ public class TGMessageFile extends TGMessage {
     switch (message.content.getConstructor()) {
       case TdApi.MessageDocument.CONSTRUCTOR: {
         TdApi.MessageDocument document = (TdApi.MessageDocument) message.content;
-        component = new FileComponent(context, document.document);
+        component = new FileComponent(context, message, document.document);
         caption = document.caption;
         break;
       }
       case TdApi.MessageAudio.CONSTRUCTOR: {
         TdApi.MessageAudio audio = (TdApi.MessageAudio) message.content;
-        component = new FileComponent(context, audio.audio, message, context.manager);
+        component = new FileComponent(context, message, audio.audio, message, context.manager);
         caption = audio.caption;
         break;
       }
       case TdApi.MessageVoiceNote.CONSTRUCTOR: {
         TdApi.MessageVoiceNote voiceNote = (TdApi.MessageVoiceNote) message.content;
-        component = new FileComponent(context, voiceNote.voiceNote, message, context.manager);
+        component = new FileComponent(context, message, voiceNote.voiceNote, message, context.manager);
         caption = voiceNote.caption;
         disallowTouch = false;
         break;

--- a/app/src/main/java/org/thunderdog/challegram/data/TGMessageMedia.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGMessageMedia.java
@@ -42,7 +42,6 @@ import org.thunderdog.challegram.tool.UI;
 import org.thunderdog.challegram.util.text.Highlight;
 import org.thunderdog.challegram.util.text.Text;
 import org.thunderdog.challegram.util.text.TextEntity;
-import org.thunderdog.challegram.util.text.TextMedia;
 import org.thunderdog.challegram.util.text.TextWrapper;
 
 import java.util.ArrayList;

--- a/app/src/main/java/org/thunderdog/challegram/data/TGWebPage.java
+++ b/app/src/main/java/org/thunderdog/challegram/data/TGWebPage.java
@@ -301,16 +301,16 @@ public class TGWebPage implements FileProgressComponent.SimpleListener, MediaWra
             if (partedUrl.length == 2) {
               this.component = new WallpaperComponent(parent, webPage, partedUrl[1]);
             } else if (webPage.document != null) {
-              this.component = new FileComponent(parent, webPage.document);
+              this.component = new FileComponent(parent, parent.getMessage(), webPage.document);
             } else {
               this.component = null;
             }
           } else if (webPage.audio != null) {
-            this.component = new FileComponent(parent, webPage.audio, null, null);
+            this.component = new FileComponent(parent, parent.getMessage(), webPage.audio, null, null);
           } else if (webPage.voiceNote != null) {
-            this.component = new FileComponent(parent, webPage.voiceNote, null, null);
+            this.component = new FileComponent(parent, parent.getMessage(), webPage.voiceNote, null, null);
           } else if (webPage.document != null) {
-            this.component = new FileComponent(parent, webPage.document);
+            this.component = new FileComponent(parent, parent.getMessage(), webPage.document);
           } else {
             this.component = null;
           }

--- a/app/src/main/java/org/thunderdog/challegram/loader/ImageFile.java
+++ b/app/src/main/java/org/thunderdog/challegram/loader/ImageFile.java
@@ -109,6 +109,10 @@ public class ImageFile {
     return tdlib != null ? tdlib.tdlib() : null;
   }
 
+  public boolean isRemote () {
+    return tdlib() != null && getId() > 0;
+  }
+
   public byte[] getBytes () {
     return bytes;
   }

--- a/app/src/main/java/org/thunderdog/challegram/loader/ImageReceiver.java
+++ b/app/src/main/java/org/thunderdog/challegram/loader/ImageReceiver.java
@@ -181,7 +181,23 @@ public class ImageReceiver implements Watcher, ValueAnimator.AnimatorUpdateListe
     }
     sourceWidth = getCroppedWidth(sourceWidth);
     sourceHeight = getCroppedHeight(sourceHeight);
-    float ratio = Math.min((float) getWidth() / (float) sourceWidth, (float) getHeight() / (float) sourceHeight);
+    float widthRatio = (float) getWidth() / (float) sourceWidth;
+    float heightRatio = (float) getHeight() / (float) sourceHeight;
+    float ratio;
+    if (file != null) {
+      switch (file.getScaleType()) {
+        case ImageFile.CENTER_CROP:
+          ratio = Math.max(widthRatio, heightRatio);
+          break;
+        case ImageFile.FIT_CENTER:
+          ratio = Math.min(widthRatio, heightRatio);
+          break;
+        default:
+          return getWidth();
+      }
+    } else {
+      ratio = Math.min(widthRatio, heightRatio);
+    }
     sourceWidth *= ratio;
     sourceHeight *= ratio;
     return sourceWidth;
@@ -210,7 +226,23 @@ public class ImageReceiver implements Watcher, ValueAnimator.AnimatorUpdateListe
     }
     sourceWidth = getCroppedWidth(sourceWidth);
     sourceHeight = getCroppedHeight(sourceHeight);
-    float ratio = Math.min((float) getWidth() / (float) sourceWidth, (float) getHeight() / (float) sourceHeight);
+    float widthRatio = (float) getWidth() / (float) sourceWidth;
+    float heightRatio = (float) getHeight() / (float) sourceHeight;
+    float ratio;
+    if (file != null) {
+      switch (file.getScaleType()) {
+        case ImageFile.CENTER_CROP:
+          ratio = Math.max(widthRatio, heightRatio);
+          break;
+        case ImageFile.FIT_CENTER:
+          ratio = Math.min(widthRatio, heightRatio);
+          break;
+        default:
+          return getWidth();
+      }
+    } else {
+      ratio = Math.min(widthRatio, heightRatio);
+    }
     sourceWidth *= ratio;
     sourceHeight *= ratio;
     return sourceHeight;

--- a/app/src/main/java/org/thunderdog/challegram/loader/gif/GifReceiver.java
+++ b/app/src/main/java/org/thunderdog/challegram/loader/gif/GifReceiver.java
@@ -169,12 +169,64 @@ public class GifReceiver implements GifWatcher, Runnable, Receiver {
 
   @Override
   public int getTargetWidth () {
-    return gif != null ? (gif.isRotated() ? gif.height() : gif.width()) : 0;
+    if (gif != null) {
+      int sourceWidth = (gif.isRotated() ? gif.height() : gif.width());
+      int sourceHeight = (gif.isRotated() ? gif.width() : gif.height());
+
+      float widthRatio = (float) getWidth() / (float) sourceWidth;
+      float heightRatio = (float) getHeight() / (float) sourceHeight;
+
+      float ratio;
+      if (file != null) {
+        switch (file.getScaleType()) {
+          case GifFile.CENTER_CROP:
+            ratio = Math.max(widthRatio, heightRatio);
+            break;
+          case GifFile.FIT_CENTER:
+            ratio = Math.min(widthRatio, heightRatio);
+            break;
+          default:
+            return getWidth();
+        }
+      } else {
+        ratio = Math.min(widthRatio, heightRatio);
+      }
+      sourceWidth *= ratio;
+      sourceHeight *= ratio;
+      return sourceWidth;
+    }
+    return getWidth();
   }
 
   @Override
   public int getTargetHeight () {
-    return gif != null ? (gif.isRotated() ? gif.width() : gif.height()) : 0;
+    if (gif != null) {
+      int sourceWidth = (gif.isRotated() ? gif.height() : gif.width());
+      int sourceHeight = (gif.isRotated() ? gif.width() : gif.height());
+
+      float widthRatio = (float) getWidth() / (float) sourceWidth;
+      float heightRatio = (float) getHeight() / (float) sourceHeight;
+
+      float ratio;
+      if (file != null) {
+        switch (file.getScaleType()) {
+          case GifFile.CENTER_CROP:
+            ratio = Math.max(widthRatio, heightRatio);
+            break;
+          case GifFile.FIT_CENTER:
+            ratio = Math.min(widthRatio, heightRatio);
+            break;
+          default:
+            return getWidth();
+        }
+      } else {
+        ratio = Math.min(widthRatio, heightRatio);
+      }
+      sourceWidth *= ratio;
+      sourceHeight *= ratio;
+      return sourceHeight;
+    }
+    return 0;
   }
 
   // ImageReceiver

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/ClippingSubsamplingImageView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/ClippingSubsamplingImageView.java
@@ -1,0 +1,95 @@
+package org.thunderdog.challegram.mediaview;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.graphics.RectF;
+
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
+
+import org.thunderdog.challegram.U;
+import org.thunderdog.challegram.support.ViewSupport;
+import org.thunderdog.challegram.tool.DrawAlgorithms;
+import org.thunderdog.challegram.tool.Paints;
+import org.thunderdog.challegram.tool.Views;
+
+public class ClippingSubsamplingImageView extends SubsamplingScaleImageView {
+  private float imageWidth, imageHeight;
+  private final RectF clip = new RectF();
+  private float topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius;
+
+  public ClippingSubsamplingImageView (Context context) {
+    super(context);
+  }
+
+  public void setClipping (float imageWidth, float imageHeight,
+                           float clipLeft, float clipTop, float clipRight, float clipBottom,
+                           float topLeftRadius, float topRightRadius,
+                           float bottomRightRadius, float bottomLeftRadius) {
+    if (this.imageWidth != imageWidth || this.imageHeight != imageHeight ||
+      U.setRect(clip, clipLeft, clipTop, clipRight, clipBottom) ||
+      this.topLeftRadius != topLeftRadius || this.topRightRadius != topRightRadius ||
+      this.bottomRightRadius != bottomRightRadius || this.bottomLeftRadius != bottomLeftRadius) {
+      this.imageWidth = imageWidth;
+      this.imageHeight = imageHeight;
+      this.topLeftRadius = topLeftRadius;
+      this.topRightRadius = topRightRadius;
+      this.bottomRightRadius = bottomRightRadius;
+      this.bottomLeftRadius = bottomLeftRadius;
+      invalidate();
+    }
+  }
+
+  public void resetClipping () {
+    setClipping(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  }
+
+  private final Path path = new Path();
+
+  @Override
+  public void onDraw (Canvas canvas) {
+    if (imageWidth == 0 || imageHeight == 0 || (clip.left == 0 && clip.top == 0 && clip.right == 0 && clip.bottom == 0 && topLeftRadius == 0 && topRightRadius == 0 && bottomRightRadius == 0 && bottomLeftRadius == 0)) {
+      super.onDraw(canvas);
+      return;
+    }
+    float centerX = getMeasuredWidth() / 2f;
+    float centerY = getMeasuredHeight() / 2f;
+    int saveCount = Views.save(canvas);
+    RectF rectF = Paints.getRectF();
+    rectF.set(
+      centerX - imageWidth / 2f + clip.left,
+      centerY - imageHeight / 2f + clip.top,
+      centerX + imageWidth / 2f - clip.right,
+      centerY + imageHeight / 2f - clip.bottom
+    );
+    canvas.clipRect(rectF);
+    if (topLeftRadius != 0 || topRightRadius != 0 || bottomRightRadius != 0 || bottomLeftRadius != 0) {
+      int imageWidth = getSWidth();
+      int imageHeight = getSHeight();
+      if (U.isRotated(getOrientation())) {
+        int temp = imageHeight;
+        imageHeight = imageWidth;
+        imageWidth = temp;
+      }
+      float scale = Math.min(
+        (float) getMeasuredWidth() / (float) imageWidth,
+        (float) getMeasuredHeight() / (float) imageHeight
+      );
+      imageWidth *= scale;
+      imageHeight *= scale;
+      if (imageWidth > 0 && imageHeight > 0) {
+        rectF.left = Math.max(rectF.left, centerX - imageWidth / 2f);
+        rectF.top = Math.max(rectF.top, centerY - imageHeight / 2f);
+        rectF.right = Math.min(rectF.right, centerX + imageWidth / 2f);
+        rectF.bottom = Math.min(rectF.bottom, centerY + imageHeight / 2f);
+      }
+
+      path.reset();
+      DrawAlgorithms.buildPath(path, rectF, topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius);
+      ViewSupport.clipPath(canvas, path);
+    }
+    super.onDraw(canvas);
+
+    Views.restore(canvas, saveCount);
+  }
+}

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/ClippingSubsamplingImageView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/ClippingSubsamplingImageView.java
@@ -52,8 +52,12 @@ public class ClippingSubsamplingImageView extends SubsamplingScaleImageView {
       super.onDraw(canvas);
       return;
     }
-    float centerX = getMeasuredWidth() / 2f;
-    float centerY = getMeasuredHeight() / 2f;
+    int paddingLeft = getPaddingLeft();
+    int paddingTop = getPaddingTop();
+    int paddingRight = getPaddingRight();
+    int paddingBottom = getPaddingBottom();
+    float centerX = paddingLeft + (getMeasuredWidth() - paddingLeft - paddingRight) / 2f;
+    float centerY = paddingTop + (getMeasuredHeight() - paddingTop - paddingBottom) / 2f;
     int saveCount = Views.save(canvas);
     RectF rectF = Paints.getRectF();
     rectF.set(

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -143,6 +143,7 @@ public class MediaCellView extends ViewGroup implements
     this.imageView.setLayoutParams(new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
     this.subsamplingImageView = new ClippingSubsamplingImageView(context) {
+      @SuppressWarnings("ClickableViewAccessibility")
       @Override
       public boolean onTouchEvent (@NonNull MotionEvent event) {
         MediaView mediaView = (MediaView) MediaCellView.this.getParent();

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -157,6 +157,7 @@ public class MediaCellView extends ViewGroup implements
         return res;
       }
     };
+    this.subsamplingImageView.setPanLimit(SubsamplingScaleImageView.PAN_LIMIT_INSIDE);
     this.subsamplingImageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE);
     this.subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_USE_EXIF);
     this.subsamplingImageView.setMaxScale(Float.MAX_VALUE);
@@ -288,7 +289,7 @@ public class MediaCellView extends ViewGroup implements
     final int parentWidth = getMeasuredWidth();
     final int parentHeight = getMeasuredHeight();
 
-    final int availWidth = fullWidth - offsetHorizontal * 2;
+    final int availWidth = fullWidth - paddingHorizontal * 2;
     final int availHeight = fullHeight - offsetBottom;
     int imageWidth, imageHeight;
     int imageWidthCropped, imageHeightCropped;
@@ -332,7 +333,7 @@ public class MediaCellView extends ViewGroup implements
     }
 
 
-    int centerX = offsetHorizontal + availWidth / 2;
+    int centerX = paddingHorizontal + availWidth / 2;
     int centerY = availHeight / 2;
 
     int exactLeft = centerX - imageWidth / 2;
@@ -443,7 +444,7 @@ public class MediaCellView extends ViewGroup implements
 
     final int childCount = getChildCount();
 
-    final int availWidth = fullWidth - offsetHorizontal * 2;
+    final int availWidth = fullWidth - paddingHorizontal * 2;
     final int availHeight = fullHeight - offsetBottom;
     int imageWidth, imageHeight;
     int imageWidthCropped, imageHeightCropped;
@@ -519,7 +520,7 @@ public class MediaCellView extends ViewGroup implements
 
       final int childCount = getChildCount();
 
-      final int availWidth = fullWidth - offsetHorizontal * 2;
+      final int availWidth = fullWidth - paddingHorizontal * 2;
       final int availHeight = fullHeight - offsetBottom;
       int imageWidth, imageHeight;
       if (media != null) {
@@ -565,7 +566,7 @@ public class MediaCellView extends ViewGroup implements
       final int parentWidth = getMeasuredWidth();
       final int parentHeight = getMeasuredHeight();
 
-      final int availWidth = fullWidth - offsetHorizontal * 2;
+      final int availWidth = fullWidth - paddingHorizontal * 2;
       final int availHeight = fullHeight - offsetBottom;
       int imageWidth, imageHeight;
       if (media != null) {
@@ -587,7 +588,7 @@ public class MediaCellView extends ViewGroup implements
         imageWidth *= ratio;
         imageHeight *= ratio;
       }
-      int centerX = offsetHorizontal + availWidth / 2;
+      int centerX = paddingHorizontal + availWidth / 2;
       int centerY = availHeight / 2;
       int exactLeft = centerX - imageWidth / 2;
       int exactRight = centerX + imageWidth / 2;
@@ -791,31 +792,39 @@ public class MediaCellView extends ViewGroup implements
 
   // Other
 
-  private int offsetTop, offsetBottom, offsetHorizontal;
+  private int offsetLeft, offsetTop, offsetRight, offsetBottom, paddingHorizontal;
   private int fullWidth, fullHeight;
 
-  public void layoutCell (int offsetLeft, int offsetTop, int offsetBottom, int width, int height) {
+  public void layoutCell (int paddingHorizontal, int offsetLeft, int offsetTop, int offsetRight, int offsetBottom, int width, int height) {
     this.fullWidth = width;
     this.fullHeight = height;
 
-    this.offsetHorizontal = offsetLeft;
+    this.paddingHorizontal = paddingHorizontal;
+    this.offsetLeft = offsetLeft;
     this.offsetTop = offsetTop;
+    this.offsetRight = offsetRight;
     this.offsetBottom = offsetBottom;
 
     layoutReceivers();
   }
 
-  public void setOffsets (int offsetLeft, int offsetTop, int offsetBottom) {
-    if (this.offsetHorizontal != offsetLeft || this.offsetTop != offsetTop || this.offsetBottom != offsetBottom) {
-      this.offsetHorizontal = offsetLeft;
+  public void setOffsets (int paddingHorizontal, int offsetLeft, int offsetTop, int offsetRight, int offsetBottom) {
+    if (this.paddingHorizontal != paddingHorizontal || this.offsetLeft != offsetLeft || this.offsetTop != offsetTop || this.offsetRight != offsetRight || this.offsetBottom != offsetBottom) {
+      this.paddingHorizontal = paddingHorizontal;
+      this.offsetLeft = offsetLeft;
       this.offsetTop = offsetTop;
+      this.offsetRight = offsetRight;
       this.offsetBottom = offsetBottom;
 
       layoutReceivers();
       invalidateImage();
+      // FIXME: bug inside SubsamplingImageView.java:1435-1436
+      // subsamplingImageView.setPadding(0, 0, 0, offsetBottom);
 
-      if (media != null && media.isVideo() && hideStaticView && playerView != null) {
-        playerView.requestLayout();
+      if (media != null) {
+        if (media.isVideo() && hideStaticView && playerView != null) {
+          playerView.requestLayout();
+        }
       }
     }
   }
@@ -876,13 +885,13 @@ public class MediaCellView extends ViewGroup implements
     }
 
     if (thumb == null || revealFactor == 1f || media == null) {
-      if (!receiver.setBounds(offsetHorizontal, offsetTop, fullWidth - offsetHorizontal, fullHeight - offsetBottom) && forceLayout) {
+      if (!receiver.setBounds(paddingHorizontal, offsetTop, fullWidth - paddingHorizontal, fullHeight - offsetBottom) && forceLayout) {
         receiver.forceBoundsLayout();
       }
-      if (!preview.setBounds(offsetHorizontal, offsetTop, fullWidth - offsetHorizontal, fullHeight - offsetBottom) && forceLayout) {
+      if (!preview.setBounds(paddingHorizontal, offsetTop, fullWidth - paddingHorizontal, fullHeight - offsetBottom) && forceLayout) {
         preview.forceBoundsLayout();
       }
-      if (!miniThumbnail.setBounds(offsetHorizontal, offsetTop, fullWidth - offsetHorizontal, fullHeight - offsetBottom) && forceLayout) {
+      if (!miniThumbnail.setBounds(paddingHorizontal, offsetTop, fullWidth - paddingHorizontal, fullHeight - offsetBottom) && forceLayout) {
         miniThumbnail.forceBoundsLayout();
       }
 
@@ -932,9 +941,9 @@ public class MediaCellView extends ViewGroup implements
       int left, top, right, bottom;
 
       if (revealFactor >= 0f) {
-        left = fromLeft + (int) ((float) (offsetHorizontal - fromLeft) * revealFactor) - clipHorizontal;
+        left = fromLeft + (int) ((float) (paddingHorizontal - fromLeft) * revealFactor) - clipHorizontal;
         top = fromTop + (int) ((float) (offsetTop - fromTop) * revealFactor) - clipVertical;
-        right = fromRight + (int) ((float) (fullWidth - offsetHorizontal - fromRight) * revealFactor) + clipHorizontal;
+        right = fromRight + (int) ((float) (fullWidth - paddingHorizontal - fromRight) * revealFactor) + clipHorizontal;
         bottom = fromBottom + (int) ((float) (fullHeight - offsetBottom - fromBottom) * revealFactor) + clipVertical;
       }/* else if (true) {
         left = fromLeft;
@@ -977,9 +986,9 @@ public class MediaCellView extends ViewGroup implements
       setPivotX(centerX);
       setPivotY(centerY);
 
-      int targetLeft = offsetHorizontal;
+      int targetLeft = paddingHorizontal;
       int targetTop = offsetTop;
-      int targetRight = fullWidth - offsetHorizontal;
+      int targetRight = fullWidth - paddingHorizontal;
       int targetBottom = fullHeight - offsetBottom;
 
       int targetWidth = targetRight - targetLeft;

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -17,6 +17,7 @@ package org.thunderdog.challegram.mediaview;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Path;
+import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.net.Uri;
@@ -1554,9 +1555,24 @@ public class MediaCellView extends ViewGroup implements
 
   public void normalizeZoom () {
     if (subsamplingModeEnabled && subsamplingImageLoaded) {
-      SubsamplingScaleImageView.AnimationBuilder b = subsamplingImageView.animateScale(subsamplingImageView.getMinScale());
+      float minScale = subsamplingImageView.getMinScale();
+      SubsamplingScaleImageView.AnimationBuilder b = subsamplingImageView
+        .animateScaleAndCenter(minScale, new PointF(
+          subsamplingImageView.getSWidth() / 2f,
+          subsamplingImageView.getHeight() / 2f
+        ));
       if (b != null) {
-        b.withDuration(ZOOM_DURATION).start();
+        b.withInterruptible(false)
+         .withDuration(ZOOM_DURATION)
+         .withOnAnimationEventListener(new SubsamplingScaleImageView.DefaultOnAnimationEventListener() {
+           @Override
+           public void onComplete () {
+             if (subsamplingImageView.getScale() != subsamplingImageView.getMinScale()) {
+               subsamplingImageView.resetScaleAndCenter();
+             }
+           }
+         })
+         .start();
       }
     } else {
       getDetector().normalizeZoom(true);

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -16,6 +16,7 @@ package org.thunderdog.challegram.mediaview;
 
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.Rect;
@@ -1072,10 +1073,12 @@ public class MediaCellView extends ViewGroup implements
     boolean clearReceiver = true;
     if (imageFile instanceof ImageFileLocal) {
       setSubsamplingModeEnabled(true);
+      subsamplingImageView.setTileBackgroundColor(item != null && item.mayBeTransparent() ? Color.WHITE : Color.TRANSPARENT);
       subsamplingImageView.setImage(ImageSource.uri(Uri.fromFile(new File(imageFile.getFilePath()))));
     } else if (imageFile instanceof ImageFileRemote || imageFile.isRemote()) {
       CancellationSignal signal = new CancellationSignal();
       this.subsamplingLoadSignal = signal;
+      subsamplingImageView.setTileBackgroundColor(item != null && item.mayBeTransparent() ? Color.WHITE : Color.TRANSPARENT);
       setSubsamplingModeEnabled(true);
       Client.ResultHandler fileHandler = remoteFileObject -> {
         if (remoteFileObject.getConstructor() == TdApi.File.CONSTRUCTOR) {

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -146,6 +146,9 @@ public class MediaCellView extends ViewGroup implements
       @SuppressWarnings("ClickableViewAccessibility")
       @Override
       public boolean onTouchEvent (@NonNull MotionEvent event) {
+        if (!subsamplingModeEnabled || !isReady()) {
+          return false;
+        }
         MediaView mediaView = (MediaView) MediaCellView.this.getParent();
         mediaView.setIgnoreDisallowInterceptTouchEvent(true);
         boolean res = super.onTouchEvent(event);
@@ -1316,6 +1319,8 @@ public class MediaCellView extends ViewGroup implements
     if (this.media == item && item != null) {
       if (item.isGif()) {
         gifReceiver.requestFile(item.getTargetGifFile());
+      } else if (item.isAvatar()) {
+        media.requestAvatar(avatarReceiver, true);
       } else {
         requestImage(item.getTargetImageFile(true));
       }
@@ -1515,7 +1520,7 @@ public class MediaCellView extends ViewGroup implements
   }
 
   public boolean canTouch (boolean isTouchDown) {
-    return getVisibility() == View.VISIBLE && getParent() instanceof MediaView && ((MediaView) getParent()).isTouchEnabled(isTouchDown) && media != null && revealFactor == 1f && !isZoomed();
+    return getVisibility() == View.VISIBLE && getParent() instanceof MediaView && ((MediaView) getParent()).isTouchEnabled(isTouchDown) && media != null && revealFactor == 1f;
   }
 
   @Override

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -264,6 +264,9 @@ public class MediaCellView extends ViewGroup implements
     if (this.subsamplingImageLoaded != isLoaded) {
       this.subsamplingImageLoaded = isLoaded;
       subsamplingImageView.setAlpha(isLoaded || forceTouchMode ? 1f : 0f);
+      if (isLoaded) {
+        imageView.invalidate();
+      }
     }
   }
 
@@ -1753,7 +1756,7 @@ public class MediaCellView extends ViewGroup implements
       }
 
       if (!hideStaticView || !videoReady) {
-        if (receiver.needPlaceholder()) {
+        if (receiver.needPlaceholder() || (subsamplingModeEnabled && !subsamplingImageView.isReady())) {
           if (preview.needPlaceholder()) {
             miniThumbnail.draw(c);
           }

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaCellView.java
@@ -1760,8 +1760,16 @@ public class MediaCellView extends ViewGroup implements
           clipPath.reset();
           RectF rectF = Paints.getRectF();
 
-          float clipWidth = Math.min(receiver.getTargetWidth(), receiver.getWidth());
-          float clipHeight = Math.min(receiver.getTargetHeight(), receiver.getHeight());
+          int targetWidth = receiver.getTargetWidth();
+          int targetHeight = receiver.getTargetHeight();
+
+          if (targetWidth == 0 || targetHeight == 0) {
+            targetWidth = preview.getTargetWidth();
+            targetHeight = preview.getTargetHeight();
+          }
+
+          float clipWidth = Math.min(targetWidth, receiver.getWidth());
+          float clipHeight = Math.min(targetHeight, receiver.getHeight());
 
           rectF.set(receiver.centerX() - clipWidth / 2f, receiver.centerY() - clipHeight / 2f, receiver.centerX() + clipWidth / 2f, receiver.centerY() + clipHeight / 2f);
           DrawAlgorithms.buildPath(clipPath, rectF, topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius);

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaStackResult.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaStackResult.java
@@ -1,0 +1,13 @@
+package org.thunderdog.challegram.mediaview;
+
+import org.thunderdog.challegram.mediaview.data.MediaStack;
+
+public class MediaStackResult {
+  public final MediaStack stack;
+  public final boolean reverseMode;
+
+  public MediaStackResult (MediaStack stack, boolean reverseMode) {
+    this.stack = stack;
+    this.reverseMode = reverseMode;
+  }
+}

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
@@ -603,12 +603,18 @@ public class MediaView extends FrameLayoutFix {
 
   private float downStartX, downStartY;
   private boolean listenMove, isMoving;
+  private boolean ignoreDisallowInterceptTouchEvent;
+
+  public void setIgnoreDisallowInterceptTouchEvent (boolean ignoreDisallowInterceptTouchEvent) {
+    this.ignoreDisallowInterceptTouchEvent = ignoreDisallowInterceptTouchEvent;
+  }
 
   @Override
   public void requestDisallowInterceptTouchEvent (boolean disallowIntercept) {
-    // Log.i("requestDisallowIntercept %b", disallowIntercept);
     this.disallowIntercept = disallowIntercept;
-    drop();
+    if (disallowIntercept && !ignoreDisallowInterceptTouchEvent) {
+      drop();
+    }
     super.requestDisallowInterceptTouchEvent(disallowIntercept);
   }
 
@@ -628,7 +634,7 @@ public class MediaView extends FrameLayoutFix {
 
   @Override
   public boolean onInterceptTouchEvent (MotionEvent e) {
-    if (disallowIntercept || disallowMove || disableTouch || detector == null) {
+    if ((disallowIntercept && (e.getAction() != MotionEvent.ACTION_DOWN || !ignoreDisallowInterceptTouchEvent)) || disallowMove || disableTouch || detector == null) {
       // Logger.v("no intercept %s %b", MotionEvent.actionToString(e.getAction()), isMoving);
       return false;
     }

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
@@ -240,8 +240,9 @@ public class MediaView extends FrameLayoutFix {
     int height = MeasureSpec.getSize(heightMeasureSpec); // UI.get().getWindow().getDecorView().getMeasuredHeight();
 
     boolean sameWidth = currentWidth == width;
+    boolean dimensionsChanged = currentHeight != height || !sameWidth;
 
-    if (currentHeight != height || !sameWidth) {
+    if (dimensionsChanged) {
       currentWidth = width;
       currentHeight = height;
       buildLayout(sameWidth);
@@ -287,8 +288,12 @@ public class MediaView extends FrameLayoutFix {
     return offsetTop;
   }
 
-  public float getCurrentZoom () {
-    return baseCell.getDetector().getZoom();
+  public boolean isZoomed () {
+    return baseCell.isZoomed();
+  }
+
+  public void normalizeZoom () {
+    baseCell.normalizeZoom();
   }
 
   private int offsetTop, offsetBottom, offsetHorizontal;
@@ -601,6 +606,7 @@ public class MediaView extends FrameLayoutFix {
 
   @Override
   public void requestDisallowInterceptTouchEvent (boolean disallowIntercept) {
+    // Log.i("requestDisallowIntercept %b", disallowIntercept);
     this.disallowIntercept = disallowIntercept;
     drop();
     super.requestDisallowInterceptTouchEvent(disallowIntercept);
@@ -638,7 +644,7 @@ public class MediaView extends FrameLayoutFix {
         listenMove = !isMoving && e.getPointerCount() == 1;
 
         if (!isMoving) {
-          detector.onTouchEvent(e);
+          return detector.onTouchEvent(e);
         }
 
         break;

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
@@ -634,7 +634,7 @@ public class MediaView extends FrameLayoutFix {
 
   @Override
   public boolean onInterceptTouchEvent (MotionEvent e) {
-    if ((disallowIntercept && (e.getAction() != MotionEvent.ACTION_DOWN || !ignoreDisallowInterceptTouchEvent)) || disallowMove || disableTouch || detector == null) {
+    if ((disallowIntercept && (e.getAction() != MotionEvent.ACTION_DOWN /*|| !ignoreDisallowInterceptTouchEvent*/)) || disallowMove || disableTouch || detector == null) {
       // Logger.v("no intercept %s %b", MotionEvent.actionToString(e.getAction()), isMoving);
       return false;
     }

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaView.java
@@ -251,33 +251,33 @@ public class MediaView extends FrameLayoutFix {
     super.onMeasure(widthMeasureSpec, heightMeasureSpec);
   }
 
-  public void setOffsetHorizontal (int offsetHorizontal) {
-    if (this.offsetHorizontal != offsetHorizontal) {
-      setOffsets(offsetHorizontal, offsetTop, offsetBottom);
+  public void setPaddingHorizontal (int paddingHorizontal) {
+    if (this.paddingHorizontal != paddingHorizontal) {
+      setOffsets(paddingHorizontal, offsetLeft, offsetTop, offsetRight, offsetBottom);
     }
   }
 
-  public void setOffsets (int offsetHorizontal, int offsetTop, int offsetBottom) {
-    if (this.offsetHorizontal != offsetHorizontal || this.offsetTop != offsetTop || this.offsetBottom != offsetBottom) {
+  public void setOffsets (int paddingHorizontal, int offsetLeft, int offsetTop, int offsetRight, int offsetBottom) {
+    if (this.paddingHorizontal != paddingHorizontal || this.offsetTop != offsetTop || this.offsetBottom != offsetBottom) {
       this.offsetTop = offsetTop;
       this.offsetBottom = offsetBottom;
-      this.offsetHorizontal = offsetHorizontal;
+      this.paddingHorizontal = paddingHorizontal;
 
       if (layoutBuilt) {
-        baseCell.setOffsets(offsetHorizontal, offsetTop, offsetBottom);
+        baseCell.setOffsets(paddingHorizontal, offsetLeft, offsetTop, offsetRight, offsetBottom);
         if (previewCell != null) {
-          previewCell.setOffsets(offsetHorizontal, offsetTop, offsetBottom);
+          previewCell.setOffsets(paddingHorizontal, offsetLeft, offsetTop, offsetRight, offsetBottom);
         }
       }
     }
   }
 
-  public void setOffsetBottom (int bottom) {
-    setOffsets(this.offsetHorizontal, this.offsetTop, bottom);
+  public void setNavigationalOffsets (int left, int right, int bottom) {
+    setOffsets(this.paddingHorizontal, left, this.offsetTop, right, bottom);
   }
 
-  public int getOffsetHorizontal () {
-    return offsetHorizontal;
+  public int getPaddingHorizontal () {
+    return paddingHorizontal;
   }
 
   public int getOffsetBottom () {
@@ -296,7 +296,7 @@ public class MediaView extends FrameLayoutFix {
     baseCell.normalizeZoom();
   }
 
-  private int offsetTop, offsetBottom, offsetHorizontal;
+  private int offsetLeft, offsetTop, offsetRight, offsetBottom, paddingHorizontal;
   private boolean layoutBuilt;
 
   private void buildLayout (boolean animated) {
@@ -318,9 +318,9 @@ public class MediaView extends FrameLayoutFix {
 
   public void layoutCells () {
     int currentHeight = this.currentHeight + getBottomAdd();
-    baseCell.layoutCell(offsetHorizontal, offsetTop, offsetBottom, currentWidth, currentHeight);
+    baseCell.layoutCell(paddingHorizontal, offsetLeft, offsetTop, offsetRight, offsetBottom, currentWidth, currentHeight);
     if (previewCell != null) {
-      previewCell.layoutCell(offsetHorizontal, offsetTop, offsetBottom, currentWidth, currentHeight);
+      previewCell.layoutCell(paddingHorizontal, offsetLeft, offsetTop, offsetRight, offsetBottom, currentWidth, currentHeight);
     }
   }
 
@@ -797,7 +797,7 @@ public class MediaView extends FrameLayoutFix {
   }
 
   public int getActualImageWidth () {
-    return getMeasuredWidth() - offsetHorizontal - offsetHorizontal;
+    return getMeasuredWidth() - paddingHorizontal - paddingHorizontal;
   }
 
   @Override

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
@@ -56,7 +56,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.drinkless.td.libcore.telegram.Client;
 import org.drinkless.td.libcore.telegram.TdApi;
 import org.thunderdog.challegram.BaseActivity;
-import org.thunderdog.challegram.BuildConfig;
 import org.thunderdog.challegram.R;
 import org.thunderdog.challegram.U;
 import org.thunderdog.challegram.component.MediaCollectorDelegate;
@@ -211,7 +210,7 @@ public class MediaViewController extends ViewController<MediaViewController.Args
     private boolean noLoadMore;
     private String customSubtitle;
 
-    private boolean forceThumbs;
+    private boolean forceThumbs, forceOpenIn;
 
     private String copyLink;
 
@@ -246,6 +245,11 @@ public class MediaViewController extends ViewController<MediaViewController.Args
 
     public Args setForceThumbs (boolean forceThumbs) {
       this.forceThumbs = forceThumbs;
+      return this;
+    }
+
+    public Args setForceOpenIn (boolean forceOpenIn) {
+      this.forceOpenIn = forceOpenIn;
       return this;
     }
 
@@ -1498,7 +1502,7 @@ public class MediaViewController extends ViewController<MediaViewController.Args
         TdApi.Chat chat = tdlib.chat(item.getSourceChatId());
 
         if (item.isLoaded() && item.canBeSaved()) {
-          if (item.isVideo() && !item.isGifType()) {
+          if ((item.isVideo() && !item.isGifType()) || (getArgumentsStrict().forceOpenIn)) {
             ids.append(R.id.btn_open);
             strings.append(R.string.OpenInExternalApp);
           }
@@ -8079,7 +8083,7 @@ public class MediaViewController extends ViewController<MediaViewController.Args
 
   // Opening and collecting photos
 
-  public static void openFromMedia (ViewController<?> context, MediaItem item, @Nullable TdApi.SearchMessagesFilter filter) {
+  public static void openFromMedia (ViewController<?> context, MediaItem item, @Nullable TdApi.SearchMessagesFilter filter, boolean forceOpenIn) {
     MediaStack stack = null;
 
     if (context.isStackLocked()) {
@@ -8098,8 +8102,9 @@ public class MediaViewController extends ViewController<MediaViewController.Args
     }
 
     Args args = new Args(context, MODE_MESSAGES, stack);
-    args.reverseMode = true;
-    args.forceThumbs = true;
+    args.reverseMode = stack.getReverseModeHint(true);
+    args.forceThumbs = stack.getForceThumbsHint(true);
+    args.forceOpenIn = forceOpenIn || (filter != null && filter.getConstructor() == TdApi.SearchMessagesFilterDocument.CONSTRUCTOR);
     args.filter = filter;
     if (context instanceof MediaCollectorDelegate) {
       ((MediaCollectorDelegate) context).modifyMediaArguments(item, args);

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
@@ -8085,8 +8085,11 @@ public class MediaViewController extends ViewController<MediaViewController.Args
     if (context.isStackLocked()) {
       return;
     }
+    if (filter == null && item.isGifType()) {
+      filter = new TdApi.SearchMessagesFilterAnimation();
+    }
     if (context instanceof MediaCollectorDelegate) {
-      stack = ((MediaCollectorDelegate) context).collectMedias(item.getSourceMessageId(), null);
+      stack = ((MediaCollectorDelegate) context).collectMedias(item.getSourceMessageId(), filter);
     }
 
     if (stack == null) {
@@ -8097,7 +8100,7 @@ public class MediaViewController extends ViewController<MediaViewController.Args
     Args args = new Args(context, MODE_MESSAGES, stack);
     args.reverseMode = true;
     args.forceThumbs = true;
-    args.filter = filter != null ? filter : item.isGifType() ? new TdApi.SearchMessagesFilterAnimation() : null;
+    args.filter = filter;
     if (context instanceof MediaCollectorDelegate) {
       ((MediaCollectorDelegate) context).modifyMediaArguments(item, args);
     }

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
@@ -1646,6 +1646,9 @@ public class MediaViewController extends ViewController<MediaViewController.Args
         if (item.getSourceVideo() != null) {
           TdApi.Video video = item.getSourceVideo();
           U.openFile(this, video);
+        } else if (item.getSourceDocument() != null) {
+          TdApi.Document document = item.getSourceDocument();
+          U.openFile(this, document.fileName, new File(document.document.local.path), document.mimeType, 0);
         }
         break;
       }

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
@@ -56,6 +56,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.drinkless.td.libcore.telegram.Client;
 import org.drinkless.td.libcore.telegram.TdApi;
 import org.thunderdog.challegram.BaseActivity;
+import org.thunderdog.challegram.BuildConfig;
 import org.thunderdog.challegram.R;
 import org.thunderdog.challegram.U;
 import org.thunderdog.challegram.component.MediaCollectorDelegate;
@@ -179,8 +180,8 @@ public class MediaViewController extends ViewController<MediaViewController.Args
   EmojiLayout.Listener, InputView.InputListener, InlineResultsWrap.OffsetProvider,
   MediaCellView.Callback, SliderView.Listener, TGLegacyManager.EmojiLoadListener, Menu, Client.ResultHandler, MoreDelegate, PopupLayout.TouchSectionProvider, FlingDetector.Callback, CallManager.CurrentCallListener, ColorPreviewView.BrushChangeListener, PaintState.UndoStateListener, MediaView.FactorChangeListener, EmojiToneHelper.Delegate, MessageListener {
 
-  private static final long REVEAL_ANIMATION_DURATION = /*BuildConfig.DEBUG ? 1800l : */180;
-  private static final long REVEAL_OPEN_ANIMATION_DURATION = /*BuildConfig.DEBUG ? 1800l : */180l;
+  private static final long REVEAL_ANIMATION_DURATION = /*BuildConfig.DEBUG ? 1800l :*/ 180;
+  private static final long REVEAL_OPEN_ANIMATION_DURATION = /*BuildConfig.DEBUG ? 1800l :*/ 180l;
 
   public static final int MODE_MESSAGES = 0; // opened from chat
   public static final int MODE_PROFILE = 1; // opened from profile or chat (in case of groups and channels)

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewController.java
@@ -56,7 +56,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.drinkless.td.libcore.telegram.Client;
 import org.drinkless.td.libcore.telegram.TdApi;
 import org.thunderdog.challegram.BaseActivity;
-import org.thunderdog.challegram.BuildConfig;
 import org.thunderdog.challegram.R;
 import org.thunderdog.challegram.U;
 import org.thunderdog.challegram.component.MediaCollectorDelegate;

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewDelegate.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/MediaViewDelegate.java
@@ -17,6 +17,6 @@ package org.thunderdog.challegram.mediaview;
 import org.thunderdog.challegram.mediaview.data.MediaItem;
 
 public interface MediaViewDelegate {
-  MediaViewThumbLocation getTargetLocation (int index, MediaItem item); // null if item is not presented on screen
+  MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item); // null if item is not presented on screen
   void setMediaItemVisible (int index, MediaItem item, boolean isVisible); // called when opening and closing photo viewer
 }

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaItem.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaItem.java
@@ -465,8 +465,11 @@ public class MediaItem implements MessageSourceProvider, InvalidateContentProvid
     }
     this.targetFile = video.video;
 
-    this.targetImage = MediaWrapper.createThumbFile(tdlib, video.video);
-    this.targetImage.setScaleType(ImageFile.FIT_CENTER);
+    // TODO: remove this targetImage at all, when video.thumbnail is available?
+    // if (previewImageFile == null) {
+      this.targetImage = MediaWrapper.createThumbFile(tdlib, video.video);
+      this.targetImage.setScaleType(ImageFile.FIT_CENTER);
+    // }
 
     this.width = video.width;
     this.height = video.height;

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaItem.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaItem.java
@@ -1257,15 +1257,7 @@ public class MediaItem implements MessageSourceProvider, InvalidateContentProvid
   }
 
   public boolean mayBeTransparent () {
-    if (sourceDocument != null && !StringUtils.isEmpty(sourceDocument.mimeType)) {
-      switch (sourceDocument.mimeType) {
-        case "image/gif":
-        case "image/webp":
-        case "image/png":
-          return true;
-      }
-    }
-    return false;
+    return sourceDocument != null && TGMimeType.isTransparentImageMimeType(sourceDocument.mimeType);
   }
 
   public boolean isRemoteVideo () {

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaItem.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaItem.java
@@ -1256,6 +1256,18 @@ public class MediaItem implements MessageSourceProvider, InvalidateContentProvid
     return false;
   }
 
+  public boolean mayBeTransparent () {
+    if (sourceDocument != null && !StringUtils.isEmpty(sourceDocument.mimeType)) {
+      switch (sourceDocument.mimeType) {
+        case "image/gif":
+        case "image/webp":
+        case "image/png":
+          return true;
+      }
+    }
+    return false;
+  }
+
   public boolean isRemoteVideo () {
     switch (type) {
       case TYPE_VIDEO:

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaStack.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaStack.java
@@ -31,6 +31,7 @@ public class MediaStack {
   private int currentIndex;
   private ArrayList<MediaItem> items;
   private int estimatedBefore, estimatedAfter;
+  private Boolean reverseModeHint, forceThumbsHint;
 
   private @Nullable
   MediaStackCallback callback;
@@ -39,6 +40,22 @@ public class MediaStack {
     this.context = context;
     this.tdlib = tdlib;
     this.currentIndex = -1;
+  }
+
+  public void setReverseModeHint (boolean reverseModeHint) {
+    this.reverseModeHint = reverseModeHint;
+  }
+
+  public boolean getReverseModeHint (boolean defaultValue) {
+    return reverseModeHint != null ? reverseModeHint : defaultValue;
+  }
+
+  public void setForceThumbsHint (boolean forceThumbsHint) {
+    this.forceThumbsHint = forceThumbsHint;
+  }
+
+  public boolean getForceThumbsHint (boolean defaultValue) {
+    return forceThumbsHint != null ? forceThumbsHint : defaultValue;
   }
 
   public void set (MediaItem item) {

--- a/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaStack.java
+++ b/app/src/main/java/org/thunderdog/challegram/mediaview/data/MediaStack.java
@@ -107,12 +107,14 @@ public class MediaStack {
     this.callback = callback;
   }
 
-  public void setEstimatedSize (int estimatedBefore, int estimatedAfter) {
+  public boolean setEstimatedSize (int estimatedBefore, int estimatedAfter) {
     if (this.estimatedBefore != estimatedBefore || this.estimatedAfter != estimatedAfter) {
       this.estimatedBefore = estimatedBefore;
       this.estimatedAfter = estimatedAfter;
       // notifyMediaChanged(false);
+      return true;
     }
+    return false;
   }
 
   public void insertItems (ArrayList<MediaItem> items, boolean onTop) {
@@ -209,6 +211,12 @@ public class MediaStack {
 
   public MediaItem lastAvalable () {
     return items != null ? items.get(items.size() - 1) : null;
+  }
+
+  public void onEndReached (boolean after) {
+    if (setEstimatedSize(after ? estimatedBefore : 0, after ? 0 : estimatedAfter)) {
+      notifyMediaChanged(true);
+    }
   }
 
   public int getCurrentIndex () {

--- a/app/src/main/java/org/thunderdog/challegram/navigation/ComplexHeaderView.java
+++ b/app/src/main/java/org/thunderdog/challegram/navigation/ComplexHeaderView.java
@@ -1007,8 +1007,8 @@ public class ComplexHeaderView extends BaseView implements RtlCheckListener, Str
   public void modifyMediaArguments (Object cause, MediaViewController.Args args) {
     args.delegate = new MediaViewDelegate() {
       @Override
-      public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
-        if (index == 0) {
+      public MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item) {
+        if (indexInStack == 0) {
           return getThumbLocation();
         }
         return null;

--- a/app/src/main/java/org/thunderdog/challegram/tool/TGMimeType.java
+++ b/app/src/main/java/org/thunderdog/challegram/tool/TGMimeType.java
@@ -147,6 +147,18 @@ public class TGMimeType {
     }
     return false;
   }
+  
+  public static boolean isTransparentImageMimeType (@Nullable String mimeType) {
+     if (!StringUtils.isEmpty(mimeType)) {
+       switch (mimeType) {
+         case "image/png":
+         case "image/webp":
+         case "image/gif":
+           return true;
+       }
+     }
+     return false;
+  }
 
   public static boolean isImageMimeType (@Nullable String mimeType) {
     if (StringUtils.isEmpty(mimeType) || !mimeType.startsWith("image/")) {

--- a/app/src/main/java/org/thunderdog/challegram/tool/TGMimeType.java
+++ b/app/src/main/java/org/thunderdog/challegram/tool/TGMimeType.java
@@ -42,6 +42,28 @@ public class TGMimeType {
      if ("tgs".equals(extension)) {
        return TdConstants.ANIMATED_STICKER_MIME_TYPE;
      }
+
+     // credits: https://github.com/angryziber/gnome-raw-thumbnailer/blob/master/data/raw-thumbnailer.xml
+     switch (extension) {
+       case "dng": return "image/x-adobe-dng";
+       case "arw": return "image/x-sony-arw";
+       case "cr2": return "image/x-canon-cr2";
+       case "crw": return "image/x-canon-crw";
+       case "dcr": return "image/x-kodak-dcr";
+       case "erf": return "image/x-epson-erf";
+       case "k25": return "image/x-kodak-k25";
+       case "kdc": return "image/x-kodak-kdc";
+       case "mrw": return "image/x-minolta-mrw";
+       case "nef": return "image/x-nikon-nef";
+       case "orf": return "image/x-olympus-orf";
+       case "pef": return "image/x-pentax-pef";
+       case "raf": return "image/x-fuji-raf";
+       case "raw": return "image/x-panasonic-raw";
+       case "sr2": return "image/x-sony-sr2";
+       case "srf": return "image/x-sony-srf";
+       case "x3f": return "image/x-sigma-x3f";
+     }
+
      return null;
   }
   public static @Nullable String extensionForMimeType (@Nullable String mimeType) {

--- a/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
@@ -9731,7 +9731,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
   }
 
   @Override
-  public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
+  public MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item) {
     if (!needTabs() || pagerScrollPosition == MediaTabsAdapter.POSITION_MESSAGES) {
       int i = manager.getAdapter().findMessageByMediaItem(item);
       if (i != -1) {
@@ -9749,7 +9749,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
     } else {
       SharedBaseController<?> c = pagerContentAdapter != null ? pagerContentAdapter.cachedItems.get(pagerScrollPosition) : null;
       if (c instanceof MediaViewDelegate) {
-        return ((MediaViewDelegate) c).getTargetLocation(index, item);
+        return ((MediaViewDelegate) c).getTargetLocation(indexInStack, item);
       }
     }
     return null;

--- a/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
@@ -96,6 +96,7 @@ import org.thunderdog.challegram.component.chat.AttachLinearLayout;
 import org.thunderdog.challegram.component.chat.AudioFile;
 import org.thunderdog.challegram.component.chat.ChatBottomBarView;
 import org.thunderdog.challegram.component.chat.ChatHeaderView;
+import org.thunderdog.challegram.component.chat.ChatSearchMembersView;
 import org.thunderdog.challegram.component.chat.CircleCounterBadgeView;
 import org.thunderdog.challegram.component.chat.CommandKeyboardLayout;
 import org.thunderdog.challegram.component.chat.CounterBadgeView;
@@ -218,7 +219,6 @@ import org.thunderdog.challegram.v.HeaderEditText;
 import org.thunderdog.challegram.v.MessagesLayoutManager;
 import org.thunderdog.challegram.v.MessagesRecyclerView;
 import org.thunderdog.challegram.widget.AvatarView;
-import org.thunderdog.challegram.component.chat.ChatSearchMembersView;
 import org.thunderdog.challegram.widget.CheckBoxView;
 import org.thunderdog.challegram.widget.CircleButton;
 import org.thunderdog.challegram.widget.CollapseListView;
@@ -9759,7 +9759,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
             TGMessage msg = manager.getAdapter().getMessage(i);
             // FIXME state with FOLLOW
             int offset = (int) messagesView.getTranslationY();
-            return msg.getMediaThumbLocation(item.getSourceMessageId(), view, view.getTop(), messagesView.getBottom() - view.getBottom(), view.getTop() + HeaderView.getSize(true) + offset);
+            return msg.getMediaThumbLocation(item.getSourceMessageId(), view, view.getTop() - getTopOffset(), messagesView.getBottom() - view.getBottom(), view.getTop() + HeaderView.getSize(true) + offset);
           }
         }
       }

--- a/app/src/main/java/org/thunderdog/challegram/ui/ProfileController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/ProfileController.java
@@ -5445,20 +5445,9 @@ public class ProfileController extends ViewController<ProfileController.Args> im
     if (currentPositionOffset != 0f) {
       return null;
     }
-    int i = 0;
-    boolean found = false;
-    for (ViewController<?> c : controllers) {
-      if (c instanceof SharedMediaController) {
-        found = true;
-        break;
-      }
-      i++;
-    }
-    if (found && currentMediaPosition == i) {
-      ViewController<?> c = pagerAdapter.findCachedControllerByPosition(i);
-      if (c != null) {
-        return ((SharedMediaController) c).collectMedias(fromMessageId, filter);
-      }
+    ViewController<?> c = pagerAdapter.findCachedControllerByPosition(currentMediaPosition);
+    if (c instanceof MediaCollectorDelegate) {
+      return ((MediaCollectorDelegate) c).collectMedias(fromMessageId, filter);
     }
     return null;
   }
@@ -5468,20 +5457,9 @@ public class ProfileController extends ViewController<ProfileController.Args> im
     if (currentPositionOffset != 0f) {
       return;
     }
-    int i = 0;
-    boolean found = false;
-    for (ViewController<?> c : controllers) {
-      if (c instanceof SharedMediaController) {
-        found = true;
-        break;
-      }
-      i++;
-    }
-    if (found && currentMediaPosition == i) {
-      ViewController<?> c = pagerAdapter.findCachedControllerByPosition(i);
-      if (c != null) {
-        ((SharedMediaController) c).modifyMediaArguments(cause, args);
-      }
+    ViewController<?> c = pagerAdapter.findCachedControllerByPosition(currentMediaPosition);
+    if (c instanceof MediaCollectorDelegate) {
+      ((MediaCollectorDelegate) c).modifyMediaArguments(cause, args);
     }
   }
 

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedBaseController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedBaseController.java
@@ -1263,7 +1263,7 @@ public abstract class SharedBaseController <T extends MessageSourceProvider> ext
     }
   }
 
-  private int indexOfMessage (long messageId) {
+  protected final int indexOfMessage (long messageId) {
     if (data == null || !supportsMessageContent()) {
       return -1;
     }
@@ -1532,12 +1532,12 @@ public abstract class SharedBaseController <T extends MessageSourceProvider> ext
 
   private final MediaViewThumbLocation location = new MediaViewThumbLocation();
 
-  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, int index, MediaItem mediaItem, int clipTop, int clipBottom) {
+  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, MediaItem mediaItem) {
     return false;
   }
 
   @Override
-  public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
+  public MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item) {
     int i = adapter.indexOfViewByLongId(item.getSourceMessageId());
     if (i == -1) {
       return null;
@@ -1557,9 +1557,11 @@ public abstract class SharedBaseController <T extends MessageSourceProvider> ext
       int clipTop = viewTop < 0 ? -viewTop : 0;
       int clipBottom = viewBottom < 0 ? -viewBottom : 0;
 
-      if (!setThumbLocation(location, view, index, item, clipTop, clipBottom)) {
-        location.set(left, top, right, bottom);
-        location.setClip(0, clipTop, 0, clipBottom);
+      location.set(left, top, right, bottom);
+      location.setClip(0, clipTop, 0, clipBottom);
+
+      if (!setThumbLocation(location, view, item)) {
+        return null;
       }
 
       return location;

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedBaseController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedBaseController.java
@@ -30,9 +30,16 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.drinkless.td.libcore.telegram.TdApi;
 import org.thunderdog.challegram.Log;
 import org.thunderdog.challegram.R;
+import org.thunderdog.challegram.component.MediaCollectorDelegate;
 import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.data.InlineResult;
 import org.thunderdog.challegram.data.TD;
+import org.thunderdog.challegram.mediaview.MediaViewController;
+import org.thunderdog.challegram.mediaview.MediaViewDelegate;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
+import org.thunderdog.challegram.mediaview.data.MediaItem;
+import org.thunderdog.challegram.mediaview.data.MediaStack;
+import org.thunderdog.challegram.navigation.HeaderView;
 import org.thunderdog.challegram.navigation.ViewController;
 import org.thunderdog.challegram.telegram.MessageListener;
 import org.thunderdog.challegram.telegram.TGLegacyManager;
@@ -68,7 +75,7 @@ import me.vkryl.td.ChatId;
 import me.vkryl.td.MessageId;
 import me.vkryl.td.Td;
 
-public abstract class SharedBaseController <T extends MessageSourceProvider> extends ViewController<SharedBaseController.Args> implements View.OnClickListener, View.OnLongClickListener, FactorAnimator.Target, MessageListener {
+public abstract class SharedBaseController <T extends MessageSourceProvider> extends ViewController<SharedBaseController.Args> implements View.OnClickListener, View.OnLongClickListener, FactorAnimator.Target, MessageListener, MediaCollectorDelegate, MediaViewDelegate {
   public static class Args {
     public long chatId, messageThreadId;
 
@@ -1467,7 +1474,6 @@ public abstract class SharedBaseController <T extends MessageSourceProvider> ext
 
   // Language
 
-
   @Override
   protected void handleLanguagePackEvent (int event, int arg1) {
     super.handleLanguagePackEvent(event, arg1);
@@ -1475,4 +1481,93 @@ public abstract class SharedBaseController <T extends MessageSourceProvider> ext
       adapter.onLanguagePackEvent(event, arg1);
     }
   }
+
+  // Media viewer
+
+  protected MediaItem toMediaItem (int index, T item, @Nullable TdApi.SearchMessagesFilter filter) {
+    return null;
+  }
+
+  @Override
+  public MediaStack collectMedias (long fromMessageId, @Nullable TdApi.SearchMessagesFilter filter) {
+    if (data == null || data.isEmpty()) {
+      return null;
+    }
+
+    ArrayList<MediaItem> items = null;
+
+    int foundIndex = -1;
+    int index = 0;
+    for (T item : data) {
+      MediaItem copy = toMediaItem(index, item, filter);
+      if (copy == null) {
+        continue;
+      }
+      if (items == null) {
+        items = new ArrayList<>();
+      }
+      if (foundIndex == -1 && copy.getSourceMessageId() == fromMessageId) {
+        foundIndex = index;
+      }
+      items.add(copy);
+      index++;
+    }
+
+    if (foundIndex == -1) {
+      return null;
+    }
+
+    MediaStack stack;
+
+    stack = new MediaStack(context, tdlib);
+    stack.set(foundIndex, items);
+
+    return stack;
+  }
+
+  @Override
+  public void modifyMediaArguments (Object cause, MediaViewController.Args args) {
+    args.delegate = this;
+  }
+
+  private final MediaViewThumbLocation location = new MediaViewThumbLocation();
+
+  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, int index, MediaItem mediaItem, int clipTop, int clipBottom) {
+    return false;
+  }
+
+  @Override
+  public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
+    int i = adapter.indexOfViewByLongId(item.getSourceMessageId());
+    if (i == -1) {
+      return null;
+    }
+    View view = recyclerView.getLayoutManager().findViewByPosition(i);
+    if (view != null) {
+      int viewTop = view.getTop();
+      int viewBottom = view.getBottom();
+      int top = viewTop + recyclerView.getTop() + HeaderView.getSize(true);
+      int bottom = top + view.getMeasuredHeight();
+      int left = view.getLeft();
+      int right = view.getRight();
+
+      if (alternateParent == null) {
+        viewTop -= SettingHolder.measureHeightForType(ListItem.TYPE_FAKE_PAGER_TOPVIEW);
+      }
+      int clipTop = viewTop < 0 ? -viewTop : 0;
+      int clipBottom = viewBottom < 0 ? -viewBottom : 0;
+
+      if (!setThumbLocation(location, view, index, item, clipTop, clipBottom)) {
+        location.set(left, top, right, bottom);
+        location.setClip(0, clipTop, 0, clipBottom);
+      }
+
+      return location;
+    }
+
+    return null;
+  }
+
+  @Override
+  public void setMediaItemVisible (int index, MediaItem item, boolean isVisible) { }
 }

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedCommonController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedCommonController.java
@@ -25,6 +25,8 @@ import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.data.InlineResult;
 import org.thunderdog.challegram.data.InlineResultCommon;
 import org.thunderdog.challegram.data.InlineResultMultiline;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
+import org.thunderdog.challegram.mediaview.data.MediaItem;
 import org.thunderdog.challegram.player.TGPlayerController;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.telegram.TdlibUi;
@@ -34,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import me.vkryl.td.MessageId;
+import me.vkryl.td.Td;
 
 public class SharedCommonController extends SharedBaseController<InlineResult<?>> implements View.OnClickListener, TGPlayerController.TrackChangeListener, TGPlayerController.PlayListBuilder {
   public SharedCommonController (Context context, Tdlib tdlib) {
@@ -317,5 +320,22 @@ public class SharedCommonController extends SharedBaseController<InlineResult<?>
     });
 
     return true;
+  }
+
+  // Media viewer
+
+  @Override
+  protected MediaItem toMediaItem (int index, InlineResult<?> item, @Nullable TdApi.SearchMessagesFilter filter) {
+    TdApi.Message message = item.getMessage();
+    if (message != null && Td.matchesFilter(message, filter)) {
+      return MediaItem.valueOf(context, tdlib, message);
+    }
+    return null;
+  }
+
+  @Override
+  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, int index, MediaItem mediaItem, int clipTop, int clipBottom) {
+    InlineResult<?> item = data.get(index);
+    return super.setThumbLocation(location, view, index, mediaItem, clipTop, clipBottom);
   }
 }

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedCommonController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedCommonController.java
@@ -334,8 +334,12 @@ public class SharedCommonController extends SharedBaseController<InlineResult<?>
   }
 
   @Override
-  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, int index, MediaItem mediaItem, int clipTop, int clipBottom) {
+  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, MediaItem mediaItem) {
+    int index = indexOfMessage(mediaItem.getSourceMessageId());
+    if (index == -1) {
+      return false;
+    }
     InlineResult<?> item = data.get(index);
-    return super.setThumbLocation(location, view, index, mediaItem, clipTop, clipBottom);
+    return item.setThumbLocation(location, view, index, mediaItem);
   }
 }

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedMediaController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedMediaController.java
@@ -24,18 +24,13 @@ import androidx.recyclerview.widget.GridLayoutManager;
 
 import org.drinkless.td.libcore.telegram.TdApi;
 import org.thunderdog.challegram.R;
-import org.thunderdog.challegram.component.MediaCollectorDelegate;
 import org.thunderdog.challegram.component.attach.GridSpacingItemDecoration;
 import org.thunderdog.challegram.config.Config;
 import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.loader.ImageFile;
 import org.thunderdog.challegram.mediaview.MediaCellView;
 import org.thunderdog.challegram.mediaview.MediaViewController;
-import org.thunderdog.challegram.mediaview.MediaViewDelegate;
-import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
 import org.thunderdog.challegram.mediaview.data.MediaItem;
-import org.thunderdog.challegram.mediaview.data.MediaStack;
-import org.thunderdog.challegram.navigation.HeaderView;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.telegram.TdlibSender;
 import org.thunderdog.challegram.telegram.TdlibUi;
@@ -54,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 import me.vkryl.android.util.ClickHelper;
 import me.vkryl.core.collection.IntList;
 
-public class SharedMediaController extends SharedBaseController<MediaItem> implements MediaCollectorDelegate, MediaViewDelegate, ClickHelper.Delegate, ForceTouchView.ActionListener {
+public class SharedMediaController extends SharedBaseController<MediaItem> implements ClickHelper.Delegate, ForceTouchView.ActionListener {
   public SharedMediaController (Context context, Tdlib tdlib) {
     super(context, tdlib);
   }
@@ -375,82 +370,12 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
     return false;
   }
 
+  // Media viewer
+
   @Override
-  public MediaStack collectMedias (long fromMessageId, @Nullable TdApi.SearchMessagesFilter filter) {
-    if (data == null || data.isEmpty()) {
-      return null;
-    }
-
-    ArrayList<MediaItem> items = null;
-
-    int foundIndex = -1;
-    int i = 0;
-    for (MediaItem mediaItem : data) {
-      MediaItem copy = MediaItem.copyOf(mediaItem);
-      if (copy == null) {
-        continue;
-      }
-      if (items == null) {
-        items = new ArrayList<>();
-      }
-      if (foundIndex == -1 && copy.getSourceMessageId() == fromMessageId) {
-        foundIndex = i;
-      }
-      items.add(copy);
-      i++;
-    }
-
-    if (foundIndex == -1) {
-      return null;
-    }
-
-    MediaStack stack;
-
-    stack = new MediaStack(context, tdlib);
-    stack.set(foundIndex, items);
-
-    return stack;
+  protected MediaItem toMediaItem (int index, MediaItem item, @Nullable TdApi.SearchMessagesFilter filter) {
+    return MediaItem.copyOf(item);
   }
-
-  @Override
-  public void modifyMediaArguments (Object cause, MediaViewController.Args args) {
-    args.delegate = this;
-  }
-
-  private MediaViewThumbLocation location = new MediaViewThumbLocation();
-
-  @Override
-  public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
-    int i = adapter.indexOfViewByLongId(item.getSourceMessageId());
-    if (i == -1) {
-      return null;
-    }
-    View view = recyclerView.getLayoutManager().findViewByPosition(i);
-    if (view != null) {
-      int viewTop = view.getTop();
-      int viewBottom = view.getBottom();
-      int top = viewTop + recyclerView.getTop() + HeaderView.getSize(true);
-      int bottom = top + view.getMeasuredHeight();
-      int left = view.getLeft();
-      int right = view.getRight();
-
-      if (alternateParent == null) {
-        viewTop -= SettingHolder.measureHeightForType(ListItem.TYPE_FAKE_PAGER_TOPVIEW);
-      }
-      int clipTop = viewTop < 0 ? -viewTop : 0;
-      int clipBottom = viewBottom < 0 ? -viewBottom : 0;
-
-      location.set(left, top, right, bottom);
-      location.setClip(0, clipTop, 0, clipBottom);
-
-      return location;
-    }
-
-    return null;
-  }
-
-  @Override
-  public void setMediaItemVisible (int index, MediaItem item, boolean isVisible) { }
 
   // Base touch events
 
@@ -476,10 +401,10 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
       MediaItem mediaItem = (MediaItem) item.getData();
       if (mediaItem.isVideo()) {
         if (mediaItem.isLoaded()) {
-          MediaViewController.openFromMedia(this, mediaItem, null);
+          MediaViewController.openFromMedia(this, mediaItem, null, false);
         } else {
           if (!mediaItem.performClick(v, x, y)) {
-            MediaViewController.openFromMedia(this, mediaItem, null);
+            MediaViewController.openFromMedia(this, mediaItem, null, false);
           }
         }
       } else if (mediaItem.getType() == MediaItem.TYPE_VIDEO_MESSAGE) {
@@ -489,7 +414,7 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
           mediaItem.performClick(v);
         }
       } else {
-        MediaViewController.openFromMedia(this, mediaItem, null);
+        MediaViewController.openFromMedia(this, mediaItem, filter, false);
       }
     }
   }

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedMediaController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedMediaController.java
@@ -28,7 +28,6 @@ import org.thunderdog.challegram.component.MediaCollectorDelegate;
 import org.thunderdog.challegram.component.attach.GridSpacingItemDecoration;
 import org.thunderdog.challegram.config.Config;
 import org.thunderdog.challegram.core.Lang;
-import org.thunderdog.challegram.data.AvatarPlaceholder;
 import org.thunderdog.challegram.loader.ImageFile;
 import org.thunderdog.challegram.mediaview.MediaCellView;
 import org.thunderdog.challegram.mediaview.MediaViewController;
@@ -36,7 +35,6 @@ import org.thunderdog.challegram.mediaview.MediaViewDelegate;
 import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
 import org.thunderdog.challegram.mediaview.data.MediaItem;
 import org.thunderdog.challegram.mediaview.data.MediaStack;
-import org.thunderdog.challegram.navigation.ComplexHeaderView;
 import org.thunderdog.challegram.navigation.HeaderView;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.telegram.TdlibSender;
@@ -436,7 +434,9 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
       int left = view.getLeft();
       int right = view.getRight();
 
-      viewTop -= SettingHolder.measureHeightForType(ListItem.TYPE_FAKE_PAGER_TOPVIEW);
+      if (alternateParent == null) {
+        viewTop -= SettingHolder.measureHeightForType(ListItem.TYPE_FAKE_PAGER_TOPVIEW);
+      }
       int clipTop = viewTop < 0 ? -viewTop : 0;
       int clipBottom = viewBottom < 0 ? -viewBottom : 0;
 
@@ -476,10 +476,10 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
       MediaItem mediaItem = (MediaItem) item.getData();
       if (mediaItem.isVideo()) {
         if (mediaItem.isLoaded()) {
-          MediaViewController.openFromMedia(this, mediaItem);
+          MediaViewController.openFromMedia(this, mediaItem, null);
         } else {
           if (!mediaItem.performClick(v, x, y)) {
-            MediaViewController.openFromMedia(this, mediaItem);
+            MediaViewController.openFromMedia(this, mediaItem, null);
           }
         }
       } else if (mediaItem.getType() == MediaItem.TYPE_VIDEO_MESSAGE) {
@@ -489,7 +489,7 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
           mediaItem.performClick(v);
         }
       } else {
-        MediaViewController.openFromMedia(this, mediaItem);
+        MediaViewController.openFromMedia(this, mediaItem, null);
       }
     }
   }

--- a/app/src/main/java/org/thunderdog/challegram/ui/SharedMediaController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/SharedMediaController.java
@@ -30,6 +30,7 @@ import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.loader.ImageFile;
 import org.thunderdog.challegram.mediaview.MediaCellView;
 import org.thunderdog.challegram.mediaview.MediaViewController;
+import org.thunderdog.challegram.mediaview.MediaViewThumbLocation;
 import org.thunderdog.challegram.mediaview.data.MediaItem;
 import org.thunderdog.challegram.telegram.Tdlib;
 import org.thunderdog.challegram.telegram.TdlibSender;
@@ -555,4 +556,9 @@ public class SharedMediaController extends SharedBaseController<MediaItem> imple
 
   @Override
   public void onAfterForceTouchAction (ForceTouchView.ForceTouchContext context, int actionId, Object arg) { }
+
+  @Override
+  protected boolean setThumbLocation (MediaViewThumbLocation location, View view, MediaItem mediaItem) {
+    return true;
+  }
 }

--- a/app/src/main/java/org/thunderdog/challegram/ui/camera/CameraController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/camera/CameraController.java
@@ -1453,7 +1453,7 @@ public class CameraController extends ViewController<Void> implements CameraDele
       MessagesController m = findOutputController();
       MediaViewController.Args args = new MediaViewController.Args(CameraController.this, MediaViewController.MODE_GALLERY, new MediaViewDelegate() {
         @Override
-        public MediaViewThumbLocation getTargetLocation (int index, MediaItem item) {
+        public MediaViewThumbLocation getTargetLocation (int indexInStack, MediaItem item) {
           MediaViewThumbLocation location = new MediaViewThumbLocation(0, 0, contentView.getMeasuredWidth(), contentView.getMeasuredHeight());
           location.setNoBounce();
           location.setNoPlaceholder();

--- a/app/src/main/java/org/thunderdog/challegram/widget/FileProgressComponent.java
+++ b/app/src/main/java/org/thunderdog/challegram/widget/FileProgressComponent.java
@@ -117,7 +117,7 @@ public class FileProgressComponent implements TdlibFilesManager.FileListener, Fa
   }
 
   private static final int FLAG_THEME = 1;
-  private static final int FLAG_IMAGE = 1 << 1;
+  private static final int FLAG_MEDIA_DOCUMENT = 1 << 1;
 
   private TdApi.Document originalDocument;
 
@@ -363,7 +363,7 @@ public class FileProgressComponent implements TdlibFilesManager.FileListener, Fa
       setDownloadedIconRes(isTheme ? R.drawable.baseline_palette_24 : R.drawable.baseline_insert_drive_file_24);
     }
     flags = BitwiseUtils.setFlag(flags, FLAG_THEME, isTheme);
-    flags = BitwiseUtils.setFlag(flags, FLAG_IMAGE, TGMimeType.isImageMimeType(document.mimeType));
+    flags = BitwiseUtils.setFlag(flags, FLAG_MEDIA_DOCUMENT, MediaItem.isMediaDocument(document));
     this.originalDocument = document;
   }
 
@@ -549,10 +549,10 @@ public class FileProgressComponent implements TdlibFilesManager.FileListener, Fa
                   runOnUiThreadOptional(c, () -> {
                     c.tdlib().ui().readCustomTheme(c, file, null, defaultOpen);
                   });
-                } else if (BitwiseUtils.getFlag(flags, FLAG_IMAGE)) {
+                } else if (BitwiseUtils.getFlag(flags, FLAG_MEDIA_DOCUMENT)) {
                   Background.instance().post(() -> {
                     MediaItem item = MediaItem.valueOf(context, tdlib, originalDocument, null);
-                    if (item != null && item.getWidth() > 0 && item.getHeight() > 0) {
+                    if (item != null) {
                       runOnUiThreadOptional(c, () -> {
                         item.setSourceMessageId(chatId, messageId);
                         MediaViewController.openFromMedia(c, item, new TdApi.SearchMessagesFilterDocument(), true);

--- a/app/src/main/java/org/thunderdog/challegram/widget/FileProgressComponent.java
+++ b/app/src/main/java/org/thunderdog/challegram/widget/FileProgressComponent.java
@@ -14,7 +14,6 @@
  */
 package org.thunderdog.challegram.widget;
 
-import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
@@ -43,7 +42,6 @@ import org.thunderdog.challegram.core.Background;
 import org.thunderdog.challegram.data.TD;
 import org.thunderdog.challegram.data.TGMessage;
 import org.thunderdog.challegram.filegen.VideoGen;
-import org.thunderdog.challegram.loader.ImageReader;
 import org.thunderdog.challegram.mediaview.MediaViewController;
 import org.thunderdog.challegram.mediaview.data.MediaItem;
 import org.thunderdog.challegram.navigation.ViewController;
@@ -557,7 +555,7 @@ public class FileProgressComponent implements TdlibFilesManager.FileListener, Fa
                     if (item != null && item.getWidth() > 0 && item.getHeight() > 0) {
                       runOnUiThreadOptional(c, () -> {
                         item.setSourceMessageId(chatId, messageId);
-                        MediaViewController.openFromMedia(c, item, new TdApi.SearchMessagesFilterDocument());
+                        MediaViewController.openFromMedia(c, item, new TdApi.SearchMessagesFilterDocument(), true);
                       });
                     } else {
                       runOnUiThreadOptional(c, defaultOpen);

--- a/app/src/main/java/org/thunderdog/challegram/widget/RootFrameLayout.java
+++ b/app/src/main/java/org/thunderdog/challegram/widget/RootFrameLayout.java
@@ -73,7 +73,7 @@ public class RootFrameLayout extends FrameLayoutFix {
     this.ignoreSystemNavigationBar = ignoreSystemNavigationBar;
   }
 
-  public void setIgnoreAll (boolean ignoreAll) {
+  public void setIgnoreAllInsets (boolean ignoreAll) {
     this.ignoreAll = ignoreAll;
   }
 
@@ -226,10 +226,12 @@ public class RootFrameLayout extends FrameLayoutFix {
     int top = wi.getSystemWindowInsetTop();
     int right = wi.getSystemWindowInsetRight();
     int bottom =  wi.getSystemWindowInsetBottom();
-    if (ignoreAll || UI.getContext(getContext()).dispatchCameraMargins(child, left, top, right, bottom)) {
+    if (UI.getContext(getContext()).dispatchCameraMargins(child, left, top, right, bottom)) {
       wi.replaceSystemWindowInsets(0, 0, 0, 0);
     } else {
-      if (ignoreBottom || (shouldIgnoreBottomMargin(child, bottom))) {
+      if (ignoreAll) {
+        wi.replaceSystemWindowInsets(0, 0, 0, 0);
+      } else if (ignoreBottom || (shouldIgnoreBottomMargin(child, bottom))) {
         wi.replaceSystemWindowInsets(left, top, right, 0);
       }
       ViewController<?> c = ViewController.findAncestor(child);
@@ -258,17 +260,21 @@ public class RootFrameLayout extends FrameLayoutFix {
     } else if (drawerGravity == Gravity.RIGHT) {
       wi = wi.replaceSystemWindowInsets(0, wi.getSystemWindowInsetTop(), wi.getSystemWindowInsetRight(), wi.getSystemWindowInsetBottom());
     }
-    lp.leftMargin = ignoreHorizontal ? 0 : wi.getSystemWindowInsetLeft();
-    lp.topMargin = topOnly ? 0 : wi.getSystemWindowInsetTop();
-    lp.rightMargin = ignoreHorizontal ? 0 : wi.getSystemWindowInsetRight();
+    int left = wi.getSystemWindowInsetLeft();
+    int top = wi.getSystemWindowInsetTop();
+    int right = wi.getSystemWindowInsetRight();
     int bottom = wi.getSystemWindowInsetBottom();
-    lp.bottomMargin = ignoreBottom || shouldIgnoreBottomMargin(child, bottom) ? 0 : bottom;
+
+    lp.leftMargin = ignoreAll || ignoreHorizontal ? 0 : left;
+    lp.topMargin = ignoreAll || topOnly ? 0 : top;
+    lp.rightMargin = ignoreAll || ignoreHorizontal ? 0 : right;
+    lp.bottomMargin = ignoreAll || ignoreBottom || shouldIgnoreBottomMargin(child, bottom) ? 0 : bottom;
     if (UI.getContext(getContext()).dispatchCameraMargins(child, lp.leftMargin, lp.topMargin, lp.rightMargin, bottom)) {
       lp.leftMargin = lp.topMargin = lp.rightMargin = lp.bottomMargin = 0;
     } else {
       ViewController<?> c = ViewController.findAncestor(child);
       if (c != null) {
-        c.dispatchInnerMargins(lp.leftMargin, lp.topMargin, lp.rightMargin, bottom);
+        c.dispatchInnerMargins(left, top, right, bottom);
       }
     }
   }


### PR DESCRIPTION
This PR improves full-screen media viewer.

It includes, but not limited to these changes:

1. Photos in in the full-screen media viewer now displayed with source quality (previously displayed with reduced quality & limited maximum resolution)
2. View media documents (photos, videos, GIFs) in the in-app viewer
3. Quickly browse all media documents after opening one from shared media
4. Zoom into photo documents of any resolution in the in-app media viewer
5. Full-screen mode in the media viewer (navigation gets hidden, no visual issues in the landscape mode on the edges of the screen)
6. Fling support for zoomed photos
7. Improved open/close animation of the media viewer in several cases
8. Numerous bugfixes