### PR TITLE
Dice fixes

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/telegram/Tdlib.java
+++ b/app/src/main/java/org/thunderdog/challegram/telegram/Tdlib.java
@@ -4049,7 +4049,7 @@ public class Tdlib implements TdlibProvider, Settings.SettingsChangeListener {
       return false;
     synchronized (dataLock) {
       if (diceEmoji != null) {
-        return ArrayUtils.contains(diceEmoji, emoji);
+        return ArrayUtils.contains(diceEmoji, text);
       }
     }
     return false;


### PR DESCRIPTION
1. Fixed a typo in [org.thunderdog.challegram.telegram.Tdlib](https://github.com/TGX-Android/Telegram-X/compare/main...GrigorenkoPV:dice?expand=1#diff-4fe065d18d907c74daead3160725d650603dc0216cf5c57ef0f2b2d708b9c842) which caused dice and similar emojis not being recognized as Telegram's special interactive emojis. 
2. If you open a context menu for a message with a dice, there is a special "Send a dice" button. Pressing it indeed sends a dice. However, this used to send this dice without replying to any messages, regardless of whether the user was writing a reply or not. This has been fixed.
3. The change above allowed to inline some constant parameters of `sendContent` method and simplify the code a bit. Furthermore, I have taken the liberty to remove the special treatment for `.webp` files, which would send them as stickers instead of documents. This does not seem to cause any issues, and even allows to get rid of a single-use `sendSticker` overload together with a special overload for `sendContent`.

Not sure if I should squash my commits or not, so I will leave them this way for now. Anyways, thanks in advance for reviewing this PR! ❤️