### PR TITLE
Proper permission checks for sending `.webp` files

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
+++ b/app/src/main/java/org/thunderdog/challegram/ui/MessagesController.java
@@ -8381,7 +8381,7 @@ public class MessagesController extends ViewController<MessagesController.Argume
     return sendContent(view, RightId.SEND_OTHER_MESSAGES, R.string.ChatDisabledStickers, R.string.ChatRestrictedStickers, R.string.ChatRestrictedStickersUntil, allowReply, initialSendOptions, () -> new TdApi.InputMessageSticker(new TdApi.InputFileId(sticker.sticker.id), null, 0, 0, emoji));
   }
 
-  private void sendSticker (String path, boolean allowReply, TdApi.MessageSendOptions initialSendOptions) {
+  private void sendWebp (String path, boolean allowReply, TdApi.MessageSendOptions initialSendOptions) {
     sendContent(null, RightId.SEND_OTHER_MESSAGES, R.string.ChatDisabledStickers, R.string.ChatRestrictedStickers, R.string.ChatRestrictedStickersUntil, allowReply, initialSendOptions, () -> new TdApi.InputMessageSticker(TD.createInputFile(path), null, 0, 0, null));
   }
 
@@ -9260,8 +9260,8 @@ public class MessagesController extends ViewController<MessagesController.Argume
           return;
         }
 
-        if (imagePath != null && imagePath.endsWith(".webp") && tdlib.getRestrictionStatus(chat, RightId.SEND_OTHER_MESSAGES) == null) {
-          sendSticker(imagePath, true, Td.newSendOptions());
+        if (imagePath != null && imagePath.endsWith(".webp")) {
+          sendWebp(imagePath, true, Td.newSendOptions());
         } else if (requestCode == Intents.ACTIVITY_RESULT_GALLERY_FILE) {
           sendFiles(mediaButton, Collections.singletonList(imagePath), false, true, Td.newSendOptions());
         } else {


### PR DESCRIPTION
Aims to fix #397

Ways to send a `.webp` file:
- [x] Clip -> Gallery tab -> scroll down -> 3 vertical dots -> send an image from gallery
- [ ] Though the new message in the case above might be even more confusing, because it says something about "stickers" even though you selected a picture from gallery
- [ ] Clip -> Gallery tab -> select a file -> send without compression
- [ ] Clip -> Gallery tab -> select 2+ files -> send without compression
- [ ] Clip -> File -> select a file & send
- [ ] Clip -> File -> select 2+ files & send
- [ ] Clip -> File -> Gallery -> select a file & send
- [ ] Clip -> File -> Gallery -> select 2+ files & send
- [ ] Clip -> File -> scroll down -> 3 vertical dots -> select a file & send
- [ ] Clip -> File -> scroll down -> 3 vertical dots -> select 2+ files & send
- [ ] Share a file from another app