### PR TITLE
Restore clipboard toasts for MIUI based on Android 13

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/config/Device.java
+++ b/app/src/main/java/org/thunderdog/challegram/config/Device.java
@@ -189,4 +189,7 @@ public class Device {
   public static final boolean ROUND_NOTIFICAITON_IMAGE = true; //MANUFACTURER != XIAOMI;
 
   public static final boolean FLYME = !StringUtils.isEmpty(Build.DISPLAY) && Build.DISPLAY.toLowerCase().contains("flyme");
+
+  // Android >= 13 has builtin clipboard toasts, but MIUI based on Android 13 ships without them
+  public static final boolean HAS_BUILTIN_CLIPBOARD_TOASTS = !IS_XIAOMI && Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU || Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU;
 }

--- a/app/src/main/java/org/thunderdog/challegram/config/Device.java
+++ b/app/src/main/java/org/thunderdog/challegram/config/Device.java
@@ -191,5 +191,5 @@ public class Device {
   public static final boolean FLYME = !StringUtils.isEmpty(Build.DISPLAY) && Build.DISPLAY.toLowerCase().contains("flyme");
 
   // Android >= 13 has builtin clipboard toasts, but MIUI based on Android 13 ships without them
-  public static final boolean HAS_BUILTIN_CLIPBOARD_TOASTS = !IS_XIAOMI && Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU || Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU;
+  public static final boolean HAS_BUILTIN_CLIPBOARD_TOASTS = IS_XIAOMI ? Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU : Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
 }

--- a/app/src/main/java/org/thunderdog/challegram/config/Device.java
+++ b/app/src/main/java/org/thunderdog/challegram/config/Device.java
@@ -85,6 +85,8 @@ public class Device {
       case "nvidia":
         return NVIDIA;
       case "xiaomi":
+      case "poco":
+      case "redmi":
         return XIAOMI;
       case "zte":
         return ZTE;

--- a/app/src/main/java/org/thunderdog/challegram/tool/UIHandler.java
+++ b/app/src/main/java/org/thunderdog/challegram/tool/UIHandler.java
@@ -15,7 +15,6 @@
 package org.thunderdog.challegram.tool;
 
 import android.content.Context;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.view.Gravity;
@@ -30,6 +29,7 @@ import org.thunderdog.challegram.Log;
 import org.thunderdog.challegram.MainActivity;
 import org.thunderdog.challegram.R;
 import org.thunderdog.challegram.U;
+import org.thunderdog.challegram.config.Device;
 import org.thunderdog.challegram.core.Lang;
 import org.thunderdog.challegram.data.TGAudio;
 import org.thunderdog.challegram.navigation.NavigationController;
@@ -358,7 +358,7 @@ public class UIHandler extends Handler {
       case COPY_TEXT: {
         try {
           U.copyText((CharSequence) msg.obj);
-          if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2 && msg.arg1 != 0) {
+          if (!Device.HAS_BUILTIN_CLIPBOARD_TOASTS && msg.arg1 != 0) {
             showCustomToast(msg.arg1, Toast.LENGTH_SHORT, 0);
           }
         } catch (Throwable t) {


### PR DESCRIPTION
Android 13 (SDK 33) has builtin clipboard notification toast (on copy).
To avoid double toasts, 6c13cb8 disabled the custom toast for devices running Android 13 and above, but MIUI based on Android 13 doesn't have this builtin notification toast.

This PR handles that by re-enabling the custom toast for Xiaomi devices running Android 13.
To also cover cases where the `Build.MANUFACTURER` isn't Xiaomi, Xiaomi manufacturer check was extended to include Poco and Redmi. 
The drawback of relying on `Build.MANUFACTURER` is that it isn't a very accurate way to tell if a device is using a MIUI rom, the user might be using a custom rom (for example). A more appropriate way requires accessing the system properties via reflection, but I don't know if that is something that fits this project.

This PR was tested with a Xiaomi Mi 11 Lite 5G running MIUI 14 (SDK 33).