### PR TITLE
Fix VS16 ZWJ sequence in big static emojis

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/emoji/Emoji.java
+++ b/app/src/main/java/org/thunderdog/challegram/emoji/Emoji.java
@@ -662,6 +662,12 @@ public class Emoji {
         return getEmojiInfo(Character.toString(code.charAt(0)) + code.charAt(2));
       }
     }
+    if (info == null) {
+      String fixed = code.replace("\uFE0F\u200D", "\u200D");
+      if (!fixed.equals(code)) {
+        return getEmojiInfo(fixed);
+      }
+    }
     /*if (info == null) {
       CharSequence fixedEmoji = fixEmoji(code);
       if (!fixedEmoji.equals(code)) {


### PR DESCRIPTION
Fixes https://t.me/tgandroidtests/260461

Some emojis have more than one variation --- with VS16 and without. Starting from #443 displaying VS16 variants was broken.

For example, "Heart with fire" can be `\u2764\u200d\ud83d\udd25` (Heart, ZWJ, Fire) --- which is displayed properly, and `\u2764\ufe0f\u200d\ud83d\udd25` (Heart, VS16, ZWJ, Fire) --- which is not.

To reproduce, use any commit since merging #443 until `3597dea4`, use "Big emoji = On" and "Animated emoji = any" and send `❤‍🔥❤️‍🔥` to any chat. Expected behavior is that both emojis are displayed the same, and actual is the second one disappears.

Incorrect, as seen on 1669:
![image](https://github.com/TGX-Android/Telegram-X/assets/44705138/95b81919-6a97-4f12-bd09-2cda0b70e85c)

Correct, as seen on this PR:
![image](https://github.com/TGX-Android/Telegram-X/assets/44705138/a029a89d-09cd-47fd-bf3d-9cf75c6265cf)

This should probably fix displaying emojis by trying to resolve them again in case they contain VS16-ZWJ pair.

I am unaware if this is the only cause of emojis disappearing, but this fix worked for me. I am still a newbie in Java and Android programming and will appreciate your comments.