### PR TITLE
Enable clipboard toasts for all MIUI/HyperOs devices

### DIFF
--- a/app/src/main/java/org/thunderdog/challegram/config/Device.java
+++ b/app/src/main/java/org/thunderdog/challegram/config/Device.java
@@ -190,6 +190,6 @@ public class Device {
 
   public static final boolean FLYME = !StringUtils.isEmpty(Build.DISPLAY) && Build.DISPLAY.toLowerCase().contains("flyme");
 
-  // Android >= 13 has builtin clipboard toasts, but MIUI based on Android 13 ships without them
-  public static final boolean HAS_BUILTIN_CLIPBOARD_TOASTS = IS_XIAOMI ? Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU : Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
+  // Android >= 13 has builtin clipboard toasts, but MIUI/HyperOs ships without them
+  public static final boolean HAS_BUILTIN_CLIPBOARD_TOASTS = !IS_XIAOMI && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
 }


### PR DESCRIPTION
#512 has restored the clipboard toast for MIUI Android 13. Some users report that the same fix is also needed for HyperOs (Android 14). To avoid having to update this check multiple times, let's remove the Android version check for these devices.

