### PR TITLE
➕ command to check SHA-256 of apk in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ In order to obtain **SHA-256** of the APK:
 
 * `$ sha256sum <path-to-apk>` on **Ubuntu**
 * `$ shasum -a 256 <path-to-apk>` on **macOS**
+* `$ certutil -hashfile <path-to-apk> SHA256` on **Windows**
 
 Once obtained, there are three ways to find out the commit for the specific checksum:
 


### PR DESCRIPTION
Added command to check SHA-256 of apk in windows



- [x] **Up-To-Date**. My PR is based on the **latest** commit of the `'main'` branch.
